### PR TITLE
feat(BE): 백엔드 공통 모듈 (BaseTimeEntity, 응답/예외 처리) 구현 (#9)

### DIFF
--- a/backend/src/main/java/com/insilenceclone/backend/BackendApplication.java
+++ b/backend/src/main/java/com/insilenceclone/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package com.insilenceclone.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/backend/src/main/java/com/insilenceclone/backend/common/entity/BaseTimeEntity.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.insilenceclone.backend.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/insilenceclone/backend/common/exception/BusinessException.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.insilenceclone.backend.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package com.insilenceclone.backend.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // 1. 공통 에러
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "C001", "입력값이 올바르지 않습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 에러입니다.");
+
+    // TODO(형욱) : 이 곳에서 각자 도메인에서 발생할 에러를 HttpStatus Enum을 참고하셔서 작성해주시면 됩니다 !! (2025-12-25)
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorResponse.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorResponse.java
@@ -1,0 +1,30 @@
+package com.insilenceclone.backend.common.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ErrorResponse {
+    private final LocalDateTime timestamp;
+    private final int status;
+    private final String code;
+    private final String message;
+
+    @Builder
+    public ErrorResponse(int status, String message, String code) {
+        this.timestamp = LocalDateTime.now();
+        this.status = status;
+        this.message = message;
+        this.code = code;
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.insilenceclone.backend.common.exception;
+
+import com.insilenceclone.backend.common.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException ex) {
+        log.error("BusinessException 발생: Code: {}, Message: {}", ex.getErrorCode().getCode(), ex.getMessage());
+
+        ErrorCode errorCode = ex.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception ex) {
+        log.error("예상치 못한 에러 발생: ", ex);
+
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/common/response/ApiResponse.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/response/ApiResponse.java
@@ -1,0 +1,31 @@
+package com.insilenceclone.backend.common.response;
+
+import com.insilenceclone.backend.common.exception.ErrorCode;
+import com.insilenceclone.backend.common.exception.ErrorResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final T data;
+    private final ErrorResponse error;
+
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>(true, null, null);
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode) {
+        return new ApiResponse<>(false, null, ErrorResponse.of(errorCode));
+    }
+
+    public static <T> ApiResponse<T> fail(ErrorResponse error) {
+        return new ApiResponse<>(false, null, error);
+    }
+}


### PR DESCRIPTION
## 💡 개요
> 효율성과 코드 통일성을 높이기 위해 필수적인 공통 모듈(응답 객체, 전역 예외 처리, 엔티티 공통 필드)을 구현하였음.

## 🔗 관련 이슈
Closes #9 

## 📝 작업 상세 내용
- [x] `ApiResponse`: 공통 응답 포맷 통일 (`success`, `data`, `error`)
- [x] `GlobalExceptionHandler`: 전역 예외 처리 및 커스텀 에러(`BusinessException`) 구현
- [x] `BaseTimeEntity`: 생성일 및 수정일(`createdAt`, `updatedAt`) 자동화

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?