### PR TITLE
feat(BE): 주문 도메인 설계 및 Entity 구현 (#17)

### DIFF
--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/entity/Order.java
@@ -1,0 +1,67 @@
+package com.insilenceclone.backend.domain.order.entity;
+
+import com.insilenceclone.backend.common.entity.BaseTimeEntity;
+import com.insilenceclone.backend.domain.order.enums.OrderStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+// Builder 패턴 사용 유도로 기본 생성자 수동 생성 제한
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "orders")
+public class Order extends BaseTimeEntity {
+
+    private static final int MILEAGE_RATE = 1;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "total_price", nullable = false)
+    private Long totalPrice;
+
+    @Column(nullable = false)
+    private String address;
+
+    // 수신자명
+    @Column(name = "receiver_name", nullable = false)
+    private String receiverName;
+
+    // 수신자 핸드폰 번호
+    @Column(name = "receiver_phone", nullable = false)
+    private String receiverPhone;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(name = "delivery_message", length = 200)
+    private String deliveryMessage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Builder
+    public Order(Long userId, Long totalPrice, String address, String receiverName, String receiverPhone, String email, String deliveryMessage, OrderStatus status) {
+        this.userId = userId;
+        this.totalPrice = totalPrice;
+        this.address = address;
+        this.receiverName = receiverName;
+        this.receiverPhone = receiverPhone;
+        this.email = email;
+        this.deliveryMessage = deliveryMessage;
+        this.status = status;
+    }
+
+    public Long calculateMileage() {
+        return this.totalPrice * MILEAGE_RATE / 100;
+    }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/entity/OrderItem.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/entity/OrderItem.java
@@ -1,0 +1,48 @@
+package com.insilenceclone.backend.domain.order.entity;
+
+import com.insilenceclone.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "order_item")
+public class OrderItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_item_id")
+    private Long id;
+
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    // 개당 가격
+    @Column(nullable = false)
+    private Long unitPrice;
+
+    // TODO: product size enum 구현 후 작성 예정 (12.26)
+    // private Size size;
+
+    @Builder
+    public OrderItem(Long orderId, Long productId, int quantity, Long unitPrice) {
+        this.orderId = orderId;
+        this.productId = productId;
+        this.quantity = quantity;
+        this.unitPrice = unitPrice;
+    }
+
+    public Long calculateTotalPrice() {
+        return this.quantity * this.unitPrice;
+    }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/enums/OrderStatus.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/enums/OrderStatus.java
@@ -1,0 +1,17 @@
+package com.insilenceclone.backend.domain.order.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderStatus {
+
+    PAYMENT_COMLETED("결제 완료"),
+    PREPARING("배송 준비중"),
+    SHIPPING("배송 중"),
+    DELIVERED("배송 완료"),
+    CANCELLED("주문 취소");
+
+    private final String description;
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/repository/OrderItemRepository.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/repository/OrderItemRepository.java
@@ -1,0 +1,11 @@
+package com.insilenceclone.backend.domain.order.repository;
+
+import com.insilenceclone.backend.domain.order.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+    // 특정 주문에 담긴 상품 조회 메소드
+    List<OrderItem> findAllByOrderId(Long orderId);
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/repository/OrderRepository.java
@@ -1,0 +1,11 @@
+package com.insilenceclone.backend.domain.order.repository;
+
+import com.insilenceclone.backend.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    // PK 간접 참조로 주문 내역 조회 메소드 추가
+    List<Order> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+}


### PR DESCRIPTION
## 💡 개요
> 간접 참조(ID 참조) 방식을 사용하여 Order(주문서)와 OrderItem(주문 상세) 엔티티를 설계함.

## 🔗 관련 이슈
Closes #17

## 📝 작업 상세 내용
- [x] Order (주문) 엔티티 구현 : 배송지 정보와 요청 사항 필드 및 이메일과 수신자 이름, 핸드폰 번호 필드 포함 및 마일리지 계산 로직 포함
- [x] OrderItem (주문 상세) 엔티티 구현 : 주문 당시 단가를 저장하여 총액 계산 로직 포함
- [x] OrderStatus Enum 작성 : 주문 상태 관리를 위한 Enum 클래스 생성
- [x] Repository 구현 : Order에서 사용자별 주문 내역 조회 메소드와 OrderItem의 특정 주문의 상세 상품 목록 조회 메소드 추가

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.