### PR TITLE
feat(BE): 인증/인가 구축 (#24)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -38,6 +38,11 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/insilenceclone/backend/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/config/SecurityConfig.java
@@ -1,0 +1,67 @@
+package com.insilenceclone.backend.common.config;
+
+import com.insilenceclone.backend.common.jwt.JwtAuthenticationFilter;
+import com.insilenceclone.backend.common.jwt.JwtTokenProvider;
+import com.insilenceclone.backend.common.jwt.RestAccessDeniedHandler;
+import com.insilenceclone.backend.common.jwt.RestAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
+    private final RestAccessDeniedHandler restAccessDeniedHandler;
+
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                // 세션 사용 안함
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(restAuthenticationEntryPoint)
+                        .accessDeniedHandler(restAccessDeniedHandler)
+                )
+                // TODO(세현): 접근 정책으로 인증 없이 허용할 api url 추가
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/login").permitAll()
+                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+
+                        // 그 외 인증 필요
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/config/SecurityConfig.java
@@ -7,7 +7,6 @@ import com.insilenceclone.backend.common.jwt.RestAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -43,7 +42,10 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable)
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
                 // 세션 사용 안함
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
@@ -9,9 +9,15 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 1. 공통 에러
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "C001", "입력값이 올바르지 않습니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 에러입니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 에러입니다."),
 
     // TODO(형욱) : 이 곳에서 각자 도메인에서 발생할 에러를 HttpStatus Enum을 참고하셔서 작성해주시면 됩니다 !! (2025-12-25)
+
+    // auth
+    AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
+    AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다."),
+    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "유효하지 않은 토큰입니다."),
+    AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "토큰이 만료되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/main/java/com/insilenceclone/backend/common/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,67 @@
+package com.insilenceclone.backend.common.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            // 1) 토큰 검증 (문제 있으면 예외 -> EntryPoint에서 401 처리)
+            jwtTokenProvider.validateToken(token);
+
+            // 2) 토큰에서 loginId 추출
+            String loginId = jwtTokenProvider.getUsernameFromJWT(token);
+
+            // 3) loginId로 UserDetails 로드 (CustomUserDetailsService가 처리)
+            UserDetails userDetails = userDetailsService.loadUserByUsername(loginId);
+
+            // 4) 인증 객체 생성 후 SecurityContext에 등록
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            userDetails.getAuthorities()
+                    );
+
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer == null) return null;
+
+        if (bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/common/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/jwt/JwtTokenProvider.java
@@ -1,0 +1,98 @@
+package com.insilenceclone.backend.common.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;   // Base64 인코딩된 문자열
+
+    @Value("${jwt.expiration}")
+    private long jwtExpiration;
+
+    @Value("${jwt.refresh-expiration}")
+    private long jwtRefreshExpiration;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        // Base64 문자열을 실제 키로 변환
+        byte[] keyBytes = Decoders.BASE64.decode(jwtSecret);
+        secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // access token 생성 메소드 (claim에 userId 추가)
+    public String createToken(String loginId, Long userId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtExpiration);
+
+        return Jwts.builder()
+                .subject(loginId)
+                .claim("userId", userId)
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // refresh token 생성 메소드 (claim에 userId 추가)
+    public String createRefreshToken(String username, Long userId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtRefreshExpiration);
+
+        return Jwts.builder()
+                .subject(username)
+                .claim("userId", userId)
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // 토큰 검증
+    public void validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+
+        } catch (SecurityException | MalformedJwtException e) {
+            throw new BadCredentialsException("Invalid JWT Token");
+        } catch (ExpiredJwtException e) {
+            throw new BadCredentialsException("Expired JWT Token");
+        } catch (UnsupportedJwtException e) {
+            throw new BadCredentialsException("Unsupported JWT Token");
+        } catch (IllegalArgumentException e) {
+            throw new BadCredentialsException("JWT Token claims empty");
+        }
+
+    }
+
+    // 토큰에서 loginId 추출
+    public String getUsernameFromJWT(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return claims.getSubject();
+    }
+
+
+    public long getRefreshExpiration() {
+
+        return jwtRefreshExpiration;
+    }
+
+}

--- a/backend/src/main/java/com/insilenceclone/backend/common/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/jwt/JwtTokenProvider.java
@@ -1,11 +1,12 @@
 package com.insilenceclone.backend.common.jwt;
 
+import com.insilenceclone.backend.common.exception.BusinessException;
+import com.insilenceclone.backend.common.exception.ErrorCode;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -67,14 +68,10 @@ public class JwtTokenProvider {
                     .build()
                     .parseSignedClaims(token);
 
-        } catch (SecurityException | MalformedJwtException e) {
-            throw new BadCredentialsException("Invalid JWT Token");
+        } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
         } catch (ExpiredJwtException e) {
-            throw new BadCredentialsException("Expired JWT Token");
-        } catch (UnsupportedJwtException e) {
-            throw new BadCredentialsException("Unsupported JWT Token");
-        } catch (IllegalArgumentException e) {
-            throw new BadCredentialsException("JWT Token claims empty");
+            throw new BusinessException(ErrorCode.AUTH_EXPIRED_TOKEN);
         }
 
     }

--- a/backend/src/main/java/com/insilenceclone/backend/common/jwt/RestAccessDeniedHandler.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/jwt/RestAccessDeniedHandler.java
@@ -1,11 +1,7 @@
 package com.insilenceclone.backend.common.jwt;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.insilenceclone.backend.common.exception.ErrorCode;
-import com.insilenceclone.backend.common.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -15,18 +11,24 @@ import java.io.IOException;
 @Component
 public class RestAccessDeniedHandler implements AccessDeniedHandler {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
-
     @Override
-    public void handle(HttpServletRequest request, HttpServletResponse response,
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
 
-        response.setStatus(HttpStatus.FORBIDDEN.value());
         response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 
-        ErrorResponse body = ErrorResponse.of(ErrorCode.AUTH_FORBIDDEN);
+        String timestamp = java.time.LocalDateTime.now().toString();
 
-        response.getWriter().write(objectMapper.writeValueAsString(body));
+        String jsonResponse = "{"
+                + "\"timestamp\":\"" + timestamp + "\","
+                + "\"status\":403,"
+                + "\"code\":\"A002\","
+                + "\"message\":\"접근 권한이 없습니다.\""
+                + "}";
+
+        response.getWriter().write(jsonResponse);
     }
 }
+

--- a/backend/src/main/java/com/insilenceclone/backend/common/jwt/RestAccessDeniedHandler.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/jwt/RestAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.insilenceclone.backend.common.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.insilenceclone.backend.common.exception.ErrorCode;
+import com.insilenceclone.backend.common.exception.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ErrorResponse body = ErrorResponse.of(ErrorCode.AUTH_FORBIDDEN);
+
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/common/jwt/RestAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/jwt/RestAuthenticationEntryPoint.java
@@ -1,12 +1,7 @@
 package com.insilenceclone.backend.common.jwt;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.insilenceclone.backend.common.exception.BusinessException;
-import com.insilenceclone.backend.common.exception.ErrorCode;
-import com.insilenceclone.backend.common.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -16,24 +11,33 @@ import java.io.IOException;
 @Component
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response,
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
 
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-        ErrorCode errorCode = ErrorCode.AUTH_UNAUTHORIZED;
+        String code = "A001";
+        String message = "인증이 필요합니다.";
 
         Throwable cause = authException.getCause();
-        if (cause instanceof BusinessException be) {
-            errorCode = be.getErrorCode();
+        if (cause instanceof com.insilenceclone.backend.common.exception.BusinessException be) {
+            code = be.getErrorCode().getCode();
+            message = be.getErrorCode().getMessage();
         }
 
-        ErrorResponse body = ErrorResponse.of(errorCode);
+        String timestamp = java.time.LocalDateTime.now().toString();
+        int status = HttpServletResponse.SC_UNAUTHORIZED;
 
-        response.getWriter().write(objectMapper.writeValueAsString(body));
+        String jsonResponse = "{"
+                + "\"timestamp\":\"" + timestamp + "\","
+                + "\"status\":" + status + ","
+                + "\"code\":\"" + code + "\","
+                + "\"message\":\"" + message + "\""
+                + "}";
+
+        response.getWriter().write(jsonResponse);
     }
 }

--- a/backend/src/main/java/com/insilenceclone/backend/common/jwt/RestAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/jwt/RestAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package com.insilenceclone.backend.common.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.insilenceclone.backend.common.exception.BusinessException;
+import com.insilenceclone.backend.common.exception.ErrorCode;
+import com.insilenceclone.backend.common.exception.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ErrorCode errorCode = ErrorCode.AUTH_UNAUTHORIZED;
+
+        Throwable cause = authException.getCause();
+        if (cause instanceof BusinessException be) {
+            errorCode = be.getErrorCode();
+        }
+
+        ErrorResponse body = ErrorResponse.of(errorCode);
+
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/entity/User.java
@@ -1,4 +1,4 @@
-package com.insilenceclone.backend.user.entity;
+package com.insilenceclone.backend.domain.user.entity;
 
 import com.insilenceclone.backend.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.insilenceclone.backend.domain.user.repository;
+
+import com.insilenceclone.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByLoginId(String loginId);
+
+    boolean existsByLoginId(String loginId);
+
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/security/CustomUser.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/security/CustomUser.java
@@ -1,0 +1,47 @@
+package com.insilenceclone.backend.domain.user.security;
+
+import com.insilenceclone.backend.domain.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUser implements UserDetails {
+
+    private final User user;
+
+    public CustomUser(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        // Spring Security에서 username으로 쓰는 값 = loginId
+        return user.getLoginId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/security/CustomUser.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/security/CustomUser.java
@@ -11,10 +11,14 @@ import java.util.Collections;
 @Getter
 public class CustomUser implements UserDetails {
 
-    private final User user;
+    private final Long id;
+    private final String loginId;
+    private final String password;
 
     public CustomUser(User user) {
-        this.user = user;
+        this.id = user.getId();
+        this.loginId = user.getLoginId();
+        this.password = user.getPassword();
     }
 
     @Override
@@ -24,13 +28,12 @@ public class CustomUser implements UserDetails {
 
     @Override
     public String getPassword() {
-        return user.getPassword();
+        return password;
     }
 
     @Override
     public String getUsername() {
-        // Spring Security에서 username으로 쓰는 값 = loginId
-        return user.getLoginId();
+        return loginId;
     }
 
     @Override

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/security/CustomUserDetailsService.java
@@ -1,0 +1,24 @@
+package com.insilenceclone.backend.domain.user.security;
+
+import com.insilenceclone.backend.domain.user.entity.User;
+import com.insilenceclone.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found = "+loginId));
+
+        return new CustomUser(user);
+    }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/security/CustomUserDetailsService.java
@@ -17,6 +17,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
         User user = userRepository.findByLoginId(loginId)
+                // TODO(세현) : errorcode로 처리
                 .orElseThrow(() -> new UsernameNotFoundException("User not found = "+loginId));
 
         return new CustomUser(user);

--- a/backend/src/main/java/com/insilenceclone/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/insilenceclone/backend/user/repository/UserRepository.java
@@ -1,8 +1,0 @@
-package com.insilenceclone.backend.user.repository;
-
-import com.insilenceclone.backend.user.entity.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserRepository extends JpaRepository<User, Long> {
-
-}


### PR DESCRIPTION
## 💡 개요
> spriing security 기반의 jwt 인증/인가 기본 골격을 구축했습니다.

## 🔗 관련 이슈
Closes #24 

## 📝 작업 상세 내용
- [ ] Spring Security 기본 설정
- [ ] JWT 기반 인증 필터
- [ ] JwtTokenProvider를 통한 토큰 생성/검증 로직 추가
- [ ] CustomUserDetailsService 연동 (loginId 기반 사용자 조회)
- [ ] 인증 실패 시 RestAuthenticationEntryPoint로 401 응답 처리
- [ ] BusinessException + ErrorCode 기반 인증 에러 코드 정리

## 📸 스크린샷 (Optional)
<img width="2398" height="1298" alt="image" src="https://github.com/user-attachments/assets/ea27cab2-dfed-4c80-a428-6b83e7f6b99e" />

## 👀 체크리스트
- [ ] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?
- [ ] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 성공 테스트는 회원가입 후 로그인을 통해 테스트해봐야 할 것 같습니다.
1. 폴더 구조에 맞춰 리팩토링이 필요할 것 같은데 어떻게 바꾸면 좋을지
2. Error 처리를 알맞게 했는지