### PR TITLE
feat(BE): 주문 생성 API 구현 (#23)

### DIFF
--- a/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
@@ -23,7 +23,9 @@ public enum ErrorCode {
     CART_USER_ID_REQUIRED(HttpStatus.BAD_REQUEST,"CA001","userId는 필수입니다."),
     CART_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CA002", "cartId는 필수입니다."),
     CART_PRODUCT_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CA003", "productId는 필수입니다."),
-    CART_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "CA004", "quantity는 1 이상이어야 합니다.");
+    CART_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "CA004", "quantity는 1 이상이어야 합니다."),
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "C005", "장바구니가 없습니다."),
+    CART_EMPTY(HttpStatus.NOT_FOUND, "C006", "장바구니가 비어있습니다.");
 
 
     private final HttpStatus status;

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/controller/OrderController.java
@@ -1,9 +1,43 @@
 package com.insilenceclone.backend.domain.order.controller;
 
+import com.insilenceclone.backend.common.response.ApiResponse;
+import com.insilenceclone.backend.domain.order.dto.request.OrderRequestDto;
+import com.insilenceclone.backend.domain.order.service.OrderService;
+import com.insilenceclone.backend.domain.user.security.CustomUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequestMapping("api/v1/orders")
+@RequiredArgsConstructor
 public class OrderController {
+
+    private final OrderService orderService;
+
+    // 바로 구매 API
+    @PostMapping("/direct")
+    public ApiResponse<Long> createOrder(
+            @AuthenticationPrincipal CustomUser userDetails,
+            @RequestBody @Valid OrderRequestDto requestDto
+    ) {
+        Long orderId = orderService.createOrder(userDetails.getId(), requestDto);
+
+        return ApiResponse.success(orderId);
+    }
+
+    // 장바구니 구매 API
+    @PostMapping("/cart")
+    public ApiResponse<Long> createOrderFromCart(
+            @AuthenticationPrincipal CustomUser userDetails,
+            @RequestBody @Valid OrderRequestDto requestDto
+    ) {
+        Long orderId = orderService.createOrderFromCart(userDetails.getId(), requestDto);
+
+        return ApiResponse.success(orderId);
+    }
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/controller/OrderController.java
@@ -1,0 +1,9 @@
+package com.insilenceclone.backend.domain.order.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("api/v1/orders")
+public class OrderController {
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/dto/request/OrderRequestDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/dto/request/OrderRequestDto.java
@@ -1,7 +1,9 @@
 package com.insilenceclone.backend.domain.order.dto.request;
 
-import com.insilenceclone.backend.domain.order.entity.OrderItem;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,8 +14,6 @@ import java.util.List;
 @Setter
 // 주문할 때 받는 정보
 public class OrderRequestDto {
-
-    List<OrderItem> items = new ArrayList<>();
 
     @NotBlank(message = "주소는 필수로 입력해야 합니다.")
     private String address;
@@ -27,8 +27,23 @@ public class OrderRequestDto {
     @NotBlank(message = "이메일은 필수로 입력해야 합니다.")
     private String email;
 
+    @NotEmpty(message = "주문 상품은 최소 1개 이상이어야 합니다.")
+    private List<OrderProductDto> products = new ArrayList<>();
+
+    private Long cartId;
+
     private String deliveryMessage;
 
     // 추후 확장성 대비
     private String paymentMethod;
+
+    @Getter
+    public static class OrderProductDto {
+
+        @NotNull
+        private Long productId;
+
+        @Min(1)
+        private int count;
+    }
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/dto/request/OrderRequestDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/dto/request/OrderRequestDto.java
@@ -1,0 +1,34 @@
+package com.insilenceclone.backend.domain.order.dto.request;
+
+import com.insilenceclone.backend.domain.order.entity.OrderItem;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+// 주문할 때 받는 정보
+public class OrderRequestDto {
+
+    List<OrderItem> items = new ArrayList<>();
+
+    @NotBlank(message = "주소는 필수로 입력해야 합니다.")
+    private String address;
+
+    @NotBlank(message = "수신자 성명은 필수로 입력해야 합니다.")
+    private String receiverName;
+
+    @NotBlank(message = "수신자 연락처는 필수로 입력해야 합니다.")
+    private String receiverPhone;
+
+    @NotBlank(message = "이메일은 필수로 입력해야 합니다.")
+    private String email;
+
+    private String deliveryMessage;
+
+    // 추후 확장성 대비
+    private String paymentMethod;
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/dto/response/OrderResponseDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/dto/response/OrderResponseDto.java
@@ -1,0 +1,15 @@
+package com.insilenceclone.backend.domain.order.dto.response;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+// 주문시 프론트에 전달할 정보
+public class OrderResponseDto {
+
+    private String orderId;
+    private String orderStatus;
+    private Long totalPrice;
+    private LocalDateTime orderedAt;
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/entity/Order.java
@@ -64,4 +64,8 @@ public class Order extends BaseTimeEntity {
     public Long calculateMileage() {
         return this.totalPrice * MILEAGE_RATE / 100;
     }
+
+    public void updateTotalPrice(Long totalPrice) {
+        this.totalPrice = totalPrice;
+    }
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/enums/OrderStatus.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/enums/OrderStatus.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum OrderStatus {
 
+    ORDERED("주문완료"),
     PAYMENT_COMLETED("결제 완료"),
     PREPARING("배송 준비중"),
     SHIPPING("배송 중"),

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/service/OrderService.java
@@ -1,0 +1,88 @@
+package com.insilenceclone.backend.domain.order.service;
+
+import com.insilenceclone.backend.domain.order.dto.request.OrderRequestDto;
+import com.insilenceclone.backend.domain.order.entity.Order;
+import com.insilenceclone.backend.domain.order.entity.OrderItem;
+import com.insilenceclone.backend.domain.order.enums.OrderStatus;
+import com.insilenceclone.backend.domain.order.repository.OrderRepository;
+import com.insilenceclone.backend.user.entity.User;
+import com.insilenceclone.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
+    // TODO: ProductRepository 의존성 주입
+
+    /* 바로 구매 */
+    @Transactional
+    public Long createOrder(Long userId, List<OrderItem> items, OrderRequestDto requestDto) {
+
+        // 임시 검증
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("회원 정보 없음"));
+
+        Order order = Order.builder()
+                .userId(userId)
+                .address(requestDto.getAddress())
+                .email(requestDto.getEmail())
+                .receiverName(requestDto.getReceiverName())
+                .receiverPhone(requestDto.getReceiverPhone())
+                .deliveryMessage(requestDto.getDeliveryMessage())
+                .status(OrderStatus.ORDERED)
+                .totalPrice(0L)
+                .build();
+        orderRepository.save(order);
+
+        for(OrderItem item : items){
+
+        }
+
+        return 0L;
+
+    }
+
+    /* 장바구니 구매 */
+    @Transactional
+    public Long createOrderFromCart(Long userId, OrderRequestDto requestDto) {
+
+        /*
+        * 1. userId 유효성 검사
+        * 2. 장바구니를 CartRepository 사용하여 조회
+        * 3. Order 객체 생성
+        * 4. List 반복문을 돌려 OrderItem으로 이관
+        * 5. Order 저장
+        * 6. 장바구니 비우기 (deleteAll)
+        * */
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("회원 정보 없음"));
+
+        // TODO : CartRepository 사용하여 조회
+        // ex. List<Cart> cartList = careRepository.findAllByUserId(userId).orElseThrow(() -> new BusinessException(ErrorCode.CART_NOT_FOUND);
+
+        // Order 객체 생성
+        Order order = Order.builder()
+                .userId(userId)
+                .address(requestDto.getAddress())
+                .email(requestDto.getEmail())
+                .receiverName(requestDto.getReceiverName())
+                .receiverPhone(requestDto.getReceiverPhone())
+                .deliveryMessage(requestDto.getDeliveryMessage())
+                .status(OrderStatus.ORDERED)
+                .totalPrice(0L)
+                .build();
+
+        // TODO : Cart 객체 불러오기
+        // 장바구니를 OrderItem으로 이관
+
+        return 0L;
+    }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/service/OrderService.java
@@ -1,17 +1,28 @@
 package com.insilenceclone.backend.domain.order.service;
 
+import com.insilenceclone.backend.common.exception.BusinessException;
+import com.insilenceclone.backend.common.exception.ErrorCode;
+import com.insilenceclone.backend.domain.cart.entity.Cart;
+import com.insilenceclone.backend.domain.cart.entity.CartItem;
+import com.insilenceclone.backend.domain.cart.repository.CartItemRepository;
+import com.insilenceclone.backend.domain.cart.repository.CartRepository;
 import com.insilenceclone.backend.domain.order.dto.request.OrderRequestDto;
 import com.insilenceclone.backend.domain.order.entity.Order;
 import com.insilenceclone.backend.domain.order.entity.OrderItem;
 import com.insilenceclone.backend.domain.order.enums.OrderStatus;
+import com.insilenceclone.backend.domain.order.repository.OrderItemRepository;
 import com.insilenceclone.backend.domain.order.repository.OrderRepository;
-import com.insilenceclone.backend.user.entity.User;
-import com.insilenceclone.backend.user.repository.UserRepository;
+import com.insilenceclone.backend.domain.product.ProductRepositoryTemp;
+import com.insilenceclone.backend.domain.product.entity.Product;
+import com.insilenceclone.backend.domain.user.entity.User;
+import com.insilenceclone.backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -19,16 +30,124 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
     private final UserRepository userRepository;
+    private final ProductRepositoryTemp productRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final CartRepository cartRepository;
+    private final CartItemRepository  cartItemRepository;
     // TODO: ProductRepository 의존성 주입
 
     /* 바로 구매 */
     @Transactional
-    public Long createOrder(Long userId, List<OrderItem> items, OrderRequestDto requestDto) {
+    public Long createOrder(Long userId, OrderRequestDto requestDto) {
 
-        // 임시 검증
+        // TODO: 임시 검증. 추후 USER_NOT_FOUND 에러코드 추가
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("회원 정보 없음"));
 
+        Order order = createBaseOrder(userId, requestDto);
+
+        Long totalPrice = 0L;
+
+        /* 주문 생성 했으니, 주문 상품 생성 */
+        for(OrderRequestDto.OrderProductDto productDto : requestDto.getProducts()) {
+            // TODO: 에러코드 추가되면 수정
+            Product product = productRepository.findById(productDto.getProductId()).orElseThrow(
+                    () -> new IllegalArgumentException("상품이 존재하지 않습니다.")
+            );
+
+            // TODO: 재고 감소 로직 (Optional)
+
+            OrderItem orderItem = OrderItem.builder()
+                    .orderId(order.getId())
+                    .productId(product.getId())
+                    .quantity(productDto.getCount())
+                    .unitPrice(product.getPrice())
+                    .build();
+
+            orderItemRepository.save(orderItem);
+
+            totalPrice += orderItem.calculateTotalPrice();
+        }
+
+        order.updateTotalPrice(totalPrice);
+
+        return order.getId();
+    }
+
+    /* 장바구니 구매 */
+    @Transactional
+    public Long createOrderFromCart(Long userId, OrderRequestDto requestDto) {
+
+        /*
+        * 흐름도
+        * 1. userId 유효성 검사
+        * 2. 장바구니를 CartRepository 사용하여 조회
+        * 3. Order 객체 생성
+        * 4. List 반복문을 돌려 OrderItem으로 이관
+        * 5. Order 저장
+        * 6. 장바구니 비우기 (deleteAll)
+        * */
+
+        // TODO: 에러코드 추가되면 수정
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("회원 정보 없음"));
+
+        // TODO : CartRepository 사용하여 조회
+         Cart cart = cartRepository.findByUserId(userId).orElseThrow(
+                 () -> new BusinessException(ErrorCode.CART_NOT_FOUND)
+         );
+
+         List<CartItem> cartItemList = cartItemRepository.findByCartId(cart.getId());
+
+         if(cartItemList.isEmpty()) {
+             throw new BusinessException(ErrorCode.CART_EMPTY);
+         }
+
+        List<Long> productIds = cartItemList.stream()
+                .map(CartItem::getProductId)
+                .toList();
+
+        List<Product> productList = productRepository.findAllById(productIds);
+
+        Map<Long, Product> productMap = new HashMap<>();
+        for (Product product : productList) {
+            productMap.put(product.getId(), product);
+        }
+
+        // Order 객체 생성
+        Order order = createBaseOrder(userId, requestDto);
+
+         Long totalPrice = 0L;
+
+        // Cart 객체 불러오기(장바구니를 OrderItem으로 이관)
+        for(CartItem cartItem : cartItemList) {
+            Product product = productMap.get(cartItem.getProductId());
+
+            // TODO: 에러코드 추가되면 수정
+            if (product == null) {
+                throw new IllegalArgumentException("상품 정보 없음");
+            }
+
+            OrderItem orderItem = OrderItem.builder()
+                    .orderId(order.getId())
+                    .productId(product.getId())
+                    .quantity(cartItem.getQuantity())
+                    .unitPrice(product.getPrice())
+                    .build();
+
+            orderItemRepository.save(orderItem);
+
+            totalPrice += orderItem.calculateTotalPrice();
+        }
+
+        order.updateTotalPrice(totalPrice);
+
+        cartItemRepository.deleteAll(cartItemList);
+
+        return order.getId();
+    }
+
+    private Order createBaseOrder(Long userId, OrderRequestDto requestDto) {
         Order order = Order.builder()
                 .userId(userId)
                 .address(requestDto.getAddress())
@@ -41,48 +160,6 @@ public class OrderService {
                 .build();
         orderRepository.save(order);
 
-        for(OrderItem item : items){
-
-        }
-
-        return 0L;
-
-    }
-
-    /* 장바구니 구매 */
-    @Transactional
-    public Long createOrderFromCart(Long userId, OrderRequestDto requestDto) {
-
-        /*
-        * 1. userId 유효성 검사
-        * 2. 장바구니를 CartRepository 사용하여 조회
-        * 3. Order 객체 생성
-        * 4. List 반복문을 돌려 OrderItem으로 이관
-        * 5. Order 저장
-        * 6. 장바구니 비우기 (deleteAll)
-        * */
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("회원 정보 없음"));
-
-        // TODO : CartRepository 사용하여 조회
-        // ex. List<Cart> cartList = careRepository.findAllByUserId(userId).orElseThrow(() -> new BusinessException(ErrorCode.CART_NOT_FOUND);
-
-        // Order 객체 생성
-        Order order = Order.builder()
-                .userId(userId)
-                .address(requestDto.getAddress())
-                .email(requestDto.getEmail())
-                .receiverName(requestDto.getReceiverName())
-                .receiverPhone(requestDto.getReceiverPhone())
-                .deliveryMessage(requestDto.getDeliveryMessage())
-                .status(OrderStatus.ORDERED)
-                .totalPrice(0L)
-                .build();
-
-        // TODO : Cart 객체 불러오기
-        // 장바구니를 OrderItem으로 이관
-
-        return 0L;
+        return order;
     }
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/product/ProductRepositoryTemp.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/product/ProductRepositoryTemp.java
@@ -1,0 +1,8 @@
+package com.insilenceclone.backend.domain.product;
+
+import com.insilenceclone.backend.domain.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepositoryTemp extends JpaRepository<Product,Long> {
+
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/product/entity/Product.java
@@ -21,8 +21,9 @@ public class Product {
     @Column(nullable = false, length = 100)
     private String name;
 
+    // 12.28 Integer -> Long으로 변경
     @Column(nullable = false)
-    private Integer price;
+    private Long price;
 
     @Column(nullable = false, length = 50)
     private String category;
@@ -34,7 +35,7 @@ public class Product {
     private String description;
 
     @Builder
-    public Product(String name, Integer price, String category, String imageUrl, String description) {
+    public Product(String name, Long price, String category, String imageUrl, String description) {
         this.name = name;
         this.price = price;
         this.category = category;


### PR DESCRIPTION
## 💡 개요
> 상품 바로 구매 및 장바구니 구매 기능을 구현

## 🔗 관련 이슈
Closes #23 

## 📝 작업 상세 내용
- [x] 상품 바로 구매 API (/direct) 구현 : 상품 상세 페이지에서 직접 주문하는 기능
- [x] 장바구니 상품 구매 API (/cart) 구현 : 유저의 장바구니를 조회하여 주문 아이템으로 이관 후 장바구니 삭제
- [x] createBaseOrder 메서드를 통해 주문 생성 공통 로직 모듈화

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> DB 관련 성능 개선은 이 PR이 머지되고 시작할 예정입니다.