### PR TITLE
feat(BE): 회원가입 (#32)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/backend/src/main/java/com/insilenceclone/backend/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -31,7 +32,7 @@ public class SecurityConfig {
 
 
     @Bean
-    public BCryptPasswordEncoder passwordEncoder() {
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
@@ -56,7 +57,7 @@ public class SecurityConfig {
                 )
                 // TODO(세현): 접근 정책으로 인증 없이 허용할 api url 추가
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/login").permitAll()
+                        .requestMatchers("/api/v1/auth/**").permitAll()
                          .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
 
                         // 그 외 인증 필요

--- a/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
@@ -19,6 +19,10 @@ public enum ErrorCode {
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "유효하지 않은 토큰입니다."),
     AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "토큰이 만료되었습니다."),
 
+    // user
+    USER_LOGIN_ID_DUPLICATED(HttpStatus.BAD_REQUEST, "U001", "이미 사용 중인 아이디입니다."),
+    USER_UNDER_MIN_AGE(HttpStatus.BAD_REQUEST, "U002", "만 14세 이상만 가입할 수 있습니다."),
+
     // cart
     CART_USER_ID_REQUIRED(HttpStatus.BAD_REQUEST,"CA001","userId는 필수입니다."),
     CART_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CA002", "cartId는 필수입니다."),

--- a/backend/src/main/java/com/insilenceclone/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.insilenceclone.backend.common.exception;
 import com.insilenceclone.backend.common.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -20,6 +22,36 @@ public class GlobalExceptionHandler {
                 .status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));
     }
+
+    // 회원가입 dto 형식 검증 예외처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(err -> err.getDefaultMessage())
+                .orElse(ErrorCode.INVALID_INPUT.getMessage());
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(ErrorCode.INVALID_INPUT.getStatus().value())
+                .code(ErrorCode.INVALID_INPUT.getCode())
+                .message(message)
+                .build();
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.fail(error));
+    }
+
+    // 회원가입 birthdate 형식 오류
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNotReadable(HttpMessageNotReadableException ex) {
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.fail(ErrorCode.INVALID_INPUT));
+    }
+
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception ex) {

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/controller/AuthController.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.insilenceclone.backend.domain.user.controller;
+
+import com.insilenceclone.backend.common.response.ApiResponse;
+import com.insilenceclone.backend.domain.user.dto.SignUpRequestDto;
+import com.insilenceclone.backend.domain.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+    // 회원가입
+    @PostMapping("/signup")
+    public ApiResponse<Void> signup(@Valid @RequestBody SignUpRequestDto signUpRequestDto) {
+        userService.signUp(signUpRequestDto);
+        return ApiResponse.success();
+    }
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/dto/SignUpRequestDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/dto/SignUpRequestDto.java
@@ -16,8 +16,8 @@ public record SignUpRequestDto(
         @NotBlank(message = "password는 필수입니다.")
         @Size(min = 8, max = 20, message = "password는 8~20자여야 합니다.")
         @Pattern(
-                regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]+$",
-                message = "password는 영문과 숫자를 모두 포함해야 합니다."
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+\\-={}\\[\\]:;\"'<>,.?/\\\\]+$",
+                message = "password는 영문과 숫자를 모두 포함해야 하며, 공백 없이 특수문자 사용이 가능합니다."
         )
         String password,
 

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/dto/SignUpRequestDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/dto/SignUpRequestDto.java
@@ -1,0 +1,56 @@
+package com.insilenceclone.backend.domain.user.dto;
+
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDate;
+
+public record SignUpRequestDto(
+        @NotBlank(message = "loginId는 필수입니다.")
+        @Size(min = 6, max = 15, message = "loginId는 6~15자여야 합니다.")
+        @Pattern(
+                regexp = "^[a-zA-Z0-9]+$",
+                message = "loginId는 영문과 숫자만 사용할 수 있습니다."
+        )
+        String loginId,
+
+        @NotBlank(message = "password는 필수입니다.")
+        @Size(min = 8, max = 20, message = "password는 8~20자여야 합니다.")
+        @Pattern(
+                regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]+$",
+                message = "password는 영문과 숫자를 모두 포함해야 합니다."
+        )
+        String password,
+
+        @NotBlank(message = "name은 필수입니다.")
+        @Size(min=2,max = 50, message = "name은 2~50자여야 합니다.")
+        @Pattern(
+                regexp = "^[가-힣a-zA-Z]+$",
+                message = "name은 한글/영문만 입력할 수 있으며 공백, 숫자, 특수문자는 허용되지 않습니다."
+        )
+        String name,
+
+        @NotBlank(message = "phone은 필수입니다.")
+        @Size(max = 20, message = "phone은 20자 이하여야 합니다.")
+        @Pattern(
+                regexp = "^[0-9]+$",
+                message = "phone은 숫자만 입력해야 합니다."
+        )
+        String phone,
+
+        @NotBlank(message = "email은 필수입니다.")
+        @Size(max = 100, message = "email은 100자 이하여야 합니다.")
+        @Pattern(
+                regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+                message = "email 형식이 올바르지 않습니다."
+        )
+        String email,
+
+        @NotNull(message = "birthDate는 필수입니다.")
+        @PastOrPresent(message = "birthDate는 오늘 이전 날짜여야 합니다.")
+        LocalDate birthDate,
+
+        // ✅ 주소만 null 허용
+        @Size(max = 255, message = "address는 255자 이하여야 합니다.")
+        String address
+) {
+}


### PR DESCRIPTION
## 💡 개요
> 회원가입 api를 구현했고 비밀번호는 암호화되어 db에 저장됩니다.

## 🔗 관련 이슈
Closes #32 

## 📝 작업 상세 내용
- [ ] 회원가입 requestDto 생성
- [ ] 회원가입 api 생성
- [ ] 회원가입에 필요한 service 로직 구현
- [ ] SecurityConfig에 권한 부여
- [ ] ErrorCode에 에러코드 추가
- [ ] 형식 오류 에러처리를 위해 GlobalExceptionHandler에 핸들러 추가

## 📸 스크린샷 (Optional)
회원가입 성공
<img width="500" alt="image" src="https://github.com/user-attachments/assets/c238d001-d354-43b3-bd26-67e614570926" />
회원가입 성공(주소 null)
<img width="500" alt="스크린샷 2025-12-28 오전 1 19 25" src="https://github.com/user-attachments/assets/e7e828a0-5ee7-4cc4-9f94-6edf44f59ed6" />
회원가입 실패 - 아이디 중복
<img width="500" alt="image" src="https://github.com/user-attachments/assets/7621404f-1b1a-4cb5-9e3b-d6f57adcca61" />
회원가입 실패 - 14세 미만 회원가입 불가 정책
<img width="500"alt="image" src="https://github.com/user-attachments/assets/76766efd-19eb-4ca8-8017-50acde87bdde" />
회원가입 실패 - 필수값 누락
<img width="500" alt="image" src="https://github.com/user-attachments/assets/61ba3716-b96d-4c57-b5be-bbfaf9814fce" />
회원가입 실패 - 형식 오류
<img width="500" alt="image" src="https://github.com/user-attachments/assets/5e31f935-e619-4d58-84c3-a54b591fbb66" />

## 👀 체크리스트
- [ ] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?
- [ ] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 회원가입 제약조건 
POST /api/v1/auth/signup (JSON)
loginId: 6-15자, 영문/숫자만(공백/특수문자 X)
password: 8~20자, 영문+숫자 반드시 포함, 공백 불가, 허용된 특수문자 사용 가능(!@#$%^&*()_+-={}[]:;\"'<>,.?/\\)
name: 2-50자, 한글만(영문/공백/숫자/특수문자 X)
phone: 숫자만(하이픈/공백 X)
email: ~~@~~.~~ 형식
birthDate: 만 14세 이상
address: 선택, 255자 이하