### PR TITLE
feat(BE): 토큰 발급 임시 api (#39)

### DIFF
--- a/backend/src/main/java/com/insilenceclone/backend/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
                 )
                 // TODO(세현): 접근 정책으로 인증 없이 허용할 api url 추가
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/auth/signup","/api/v1/auth/dev-token").permitAll()
                          .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
 
                         // 그 외 인증 필요

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/controller/AuthController.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/controller/AuthController.java
@@ -1,14 +1,18 @@
 package com.insilenceclone.backend.domain.user.controller;
 
+import com.insilenceclone.backend.common.exception.BusinessException;
+import com.insilenceclone.backend.common.exception.ErrorCode;
+import com.insilenceclone.backend.common.jwt.JwtTokenProvider;
 import com.insilenceclone.backend.common.response.ApiResponse;
 import com.insilenceclone.backend.domain.user.dto.SignUpRequestDto;
+import com.insilenceclone.backend.domain.user.entity.User;
+import com.insilenceclone.backend.domain.user.repository.UserRepository;
+import com.insilenceclone.backend.domain.user.security.CustomUser;
 import com.insilenceclone.backend.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -16,10 +20,36 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final UserService userService;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
     // 회원가입
     @PostMapping("/signup")
     public ApiResponse<Void> signup(@Valid @RequestBody SignUpRequestDto signUpRequestDto) {
         userService.signUp(signUpRequestDto);
         return ApiResponse.success();
     }
+
+
+    // ⚠️ 임시: 로그인 구현 전 테스트용 (나중에 꼭 삭제)
+    @PostMapping("/dev-token")
+    public ApiResponse<String> devToken(@RequestParam String loginId) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT)); // 대충 처리
+
+        String token = jwtTokenProvider.createToken(user.getLoginId(), user.getId());
+        return ApiResponse.success(token);
+    }
+    /**
+     * ✅ 인증 확인 API (토큰 넣고 호출하면 현재 사용자 정보가 내려와야 함)
+     */
+    @GetMapping("/test/me")
+    public ApiResponse<MeResponse> me(@AuthenticationPrincipal CustomUser principal) {
+        // principal이 null이면 인증이 안 된 상태(=필터가 인증 객체 세팅 못함 or 토큰 없음)
+        if (principal == null) {
+            return ApiResponse.success(new MeResponse(null, null, false));
+        }
+        return ApiResponse.success(new MeResponse(principal.getId(), principal.getUsername(), true));
+    }
+
+    public record MeResponse(Long userId, String loginId, boolean authenticated) {}
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/dto/SignUpRequestDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/dto/SignUpRequestDto.java
@@ -24,8 +24,8 @@ public record SignUpRequestDto(
         @NotBlank(message = "name은 필수입니다.")
         @Size(min=2,max = 50, message = "name은 2~50자여야 합니다.")
         @Pattern(
-                regexp = "^[가-힣a-zA-Z]+$",
-                message = "name은 한글/영문만 입력할 수 있으며 공백, 숫자, 특수문자는 허용되지 않습니다."
+                regexp = "^[가-힣]+$",
+                message = "name은 한글만 입력할 수 있으며 공백, 숫자, 특수문자는 허용되지 않습니다."
         )
         String name,
 


### PR DESCRIPTION
## 💡 개요
> 로그인 api 구현 전까지 사용

## 🔗 관련 이슈
Closes #39 

## 📝 작업 상세 내용
- [ ] 로그인 구현 전 테스트 용 api 추가
- [ ] http://localhost:8080/api/v1/auth/dev-token?loginId=
- [ ] user 테이블에 있는 데이터를 보고 loginId에 값 넣으면 accesstoken 발급됨
- [ ] 헤더에 Authorization Bearer 토큰 해서 api 테스트
- [ ] 
## 📸 스크린샷 (Optional)
<img width="722" height="604" alt="스크린샷 2025-12-28 오전 2 40 44" src="https://github.com/user-attachments/assets/88ca7af0-6982-42d6-a934-8a5458951e97" />
<img width="709" height="578" alt="스크린샷 2025-12-28 오전 2 21 43" src="https://github.com/user-attachments/assets/bbe6631f-4d7c-4414-868e-5d5195fba4d0" />

## 👀 체크리스트
- [ ] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?
- [ ] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> POST  http://localhost:8080/api/v1/auth/dev-token?loginId=
토큰 테스트 api : GET http://localhost:8080/api/v1/auth/test/me