### PR TITLE
feat(BE): 로그인 구현 (#41)

### DIFF
--- a/backend/src/main/java/com/insilenceclone/backend/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
                 )
                 // TODO(세현): 접근 정책으로 인증 없이 허용할 api url 추가
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/signup","/api/v1/auth/dev-token").permitAll()
+                        .requestMatchers("/api/v1/auth/**").permitAll()
                          .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
 
                         // 그 외 인증 필요

--- a/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
@@ -18,10 +18,12 @@ public enum ErrorCode {
     AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "유효하지 않은 토큰입니다."),
     AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "토큰이 만료되었습니다."),
+    AUTH_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "A005", "아이디 또는 비밀번호가 올바르지 않습니다."),
 
     // user
     USER_LOGIN_ID_DUPLICATED(HttpStatus.BAD_REQUEST, "U001", "이미 사용 중인 아이디입니다."),
     USER_UNDER_MIN_AGE(HttpStatus.BAD_REQUEST, "U002", "만 14세 이상만 가입할 수 있습니다."),
+    
 
     // cart
     CART_USER_ID_REQUIRED(HttpStatus.BAD_REQUEST,"CA001","userId는 필수입니다."),

--- a/backend/src/main/java/com/insilenceclone/backend/common/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/jwt/JwtTokenProvider.java
@@ -86,6 +86,22 @@ public class JwtTokenProvider {
         return claims.getSubject();
     }
 
+    public Long getUserIdFromJWT(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        Object userId = claims.get("userId");
+        if (userId == null) return null;
+
+        if (userId instanceof Number number) {
+            return number.longValue();
+        }
+        return Long.parseLong(userId.toString());
+    }
+
 
     public long getRefreshExpiration() {
 

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/controller/AuthController.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/controller/AuthController.java
@@ -4,7 +4,9 @@ import com.insilenceclone.backend.common.exception.BusinessException;
 import com.insilenceclone.backend.common.exception.ErrorCode;
 import com.insilenceclone.backend.common.jwt.JwtTokenProvider;
 import com.insilenceclone.backend.common.response.ApiResponse;
-import com.insilenceclone.backend.domain.user.dto.SignUpRequestDto;
+import com.insilenceclone.backend.domain.user.dto.request.LoginRequestDto;
+import com.insilenceclone.backend.domain.user.dto.request.SignUpRequestDto;
+import com.insilenceclone.backend.domain.user.dto.response.TokenResponseDto;
 import com.insilenceclone.backend.domain.user.entity.User;
 import com.insilenceclone.backend.domain.user.repository.UserRepository;
 import com.insilenceclone.backend.domain.user.security.CustomUser;
@@ -29,6 +31,11 @@ public class AuthController {
         return ApiResponse.success();
     }
 
+    @PostMapping("/login")
+    public ApiResponse<TokenResponseDto> login(@Valid @RequestBody LoginRequestDto loginRequestDto) {
+        TokenResponseDto token = userService.login(loginRequestDto);
+        return ApiResponse.success(token);
+    }
 
     // ⚠️ 임시: 로그인 구현 전 테스트용 (나중에 꼭 삭제)
     @PostMapping("/dev-token")

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/controller/AuthController.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/controller/AuthController.java
@@ -1,19 +1,12 @@
 package com.insilenceclone.backend.domain.user.controller;
 
-import com.insilenceclone.backend.common.exception.BusinessException;
-import com.insilenceclone.backend.common.exception.ErrorCode;
-import com.insilenceclone.backend.common.jwt.JwtTokenProvider;
 import com.insilenceclone.backend.common.response.ApiResponse;
 import com.insilenceclone.backend.domain.user.dto.request.LoginRequestDto;
 import com.insilenceclone.backend.domain.user.dto.request.SignUpRequestDto;
 import com.insilenceclone.backend.domain.user.dto.response.TokenResponseDto;
-import com.insilenceclone.backend.domain.user.entity.User;
-import com.insilenceclone.backend.domain.user.repository.UserRepository;
-import com.insilenceclone.backend.domain.user.security.CustomUser;
 import com.insilenceclone.backend.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -22,8 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final UserService userService;
-    private final UserRepository userRepository;
-    private final JwtTokenProvider jwtTokenProvider;
+
     // 회원가입
     @PostMapping("/signup")
     public ApiResponse<Void> signup(@Valid @RequestBody SignUpRequestDto signUpRequestDto) {

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/controller/AuthController.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/controller/AuthController.java
@@ -36,27 +36,4 @@ public class AuthController {
         TokenResponseDto token = userService.login(loginRequestDto);
         return ApiResponse.success(token);
     }
-
-    // ⚠️ 임시: 로그인 구현 전 테스트용 (나중에 꼭 삭제)
-    @PostMapping("/dev-token")
-    public ApiResponse<String> devToken(@RequestParam String loginId) {
-        User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT)); // 대충 처리
-
-        String token = jwtTokenProvider.createToken(user.getLoginId(), user.getId());
-        return ApiResponse.success(token);
-    }
-    /**
-     * ✅ 인증 확인 API (토큰 넣고 호출하면 현재 사용자 정보가 내려와야 함)
-     */
-    @GetMapping("/test/me")
-    public ApiResponse<MeResponse> me(@AuthenticationPrincipal CustomUser principal) {
-        // principal이 null이면 인증이 안 된 상태(=필터가 인증 객체 세팅 못함 or 토큰 없음)
-        if (principal == null) {
-            return ApiResponse.success(new MeResponse(null, null, false));
-        }
-        return ApiResponse.success(new MeResponse(principal.getId(), principal.getUsername(), true));
-    }
-
-    public record MeResponse(Long userId, String loginId, boolean authenticated) {}
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/dto/request/LoginRequestDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/dto/request/LoginRequestDto.java
@@ -1,0 +1,11 @@
+package com.insilenceclone.backend.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequestDto(
+        @NotBlank(message = "로그인 아이디를 입력해주세요")
+        String loginId,
+        @NotBlank(message = "비밀번호를 입력해주세요")
+        String password
+) {
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/dto/request/SignUpRequestDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/dto/request/SignUpRequestDto.java
@@ -1,4 +1,4 @@
-package com.insilenceclone.backend.domain.user.dto;
+package com.insilenceclone.backend.domain.user.dto.request;
 
 import jakarta.validation.constraints.*;
 

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/dto/response/TokenResponseDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/dto/response/TokenResponseDto.java
@@ -1,0 +1,6 @@
+package com.insilenceclone.backend.domain.user.dto.response;
+
+public record TokenResponseDto(
+        String accessToken
+) {
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/service/UserService.java
@@ -9,7 +9,6 @@ import com.insilenceclone.backend.domain.user.dto.response.TokenResponseDto;
 import com.insilenceclone.backend.domain.user.entity.User;
 import com.insilenceclone.backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.token.TokenService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;


### PR DESCRIPTION
## 💡 개요
> 로그인 api 구현했으며 accesstoken만 발급받습니다.
refresh token 관련 메서드는 추후 서버 로그아웃/재발급 기능 확장 가능성을 고려해 유지했습니다.

## 🔗 관련 이슈
Closes #41 

## 📝 작업 상세 내용
- [x] 로그인 요청 DTO(LoginRequestDto), 응답 DTO(TokenResponseDto) 생성
- [x] 로그인 서비스 로직 구현 (아이디/비밀번호 검증 후 토큰 발급)
- [x] 로그인 API 생성
- [x] 로그인 실패 케이스 ErrorCode 추가 (로그인 실패 공통 메시지)
- [x] SecurityConfig에서 /api/v1/auth/login permitAll 적용
- [x] Postman 테스트 완료

## 📸 스크린샷 (Optional)
로그인 성공 (accesstoken 발급)
<img width="500" alt="image" src="https://github.com/user-attachments/assets/c86f8049-129b-4827-9ca5-a7df7c067a1b" />
로그인 실패 - 존재하지 않는 아이디
<img width="500" alt="image" src="https://github.com/user-attachments/assets/50563437-21ee-420b-a3a6-e91101902a9c" />
로그인 실패 - 비밀번호 불일치
<img width="500" alt="image" src="https://github.com/user-attachments/assets/a2261b8b-f35d-4687-9880-85c84db6b511" />


## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 로그아웃은 프론트에서 토큰 제거 방식으로 진행 예정이라 서버 측 refresh token/재발급은 이번 범위에서 제외했습니다.
추후 서버 로그아웃(블랙리스트) + 토큰 재발급이 필요해지면 refresh token 발급/저장 로직을 추가할 계획입니다.