### PR TITLE
feat(BE): 회원가입에서 장바구니 생성하도록 추가 (#45)

### DIFF
--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/repository/CartRepository.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/repository/CartRepository.java
@@ -10,4 +10,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     // 유저 장바구니 조회
     Optional<Cart> findByUserId(Long userId);
 
+    boolean existsByUserId(Long userId);
+
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.insilenceclone.backend.domain.user.service;
 import com.insilenceclone.backend.common.exception.BusinessException;
 import com.insilenceclone.backend.common.exception.ErrorCode;
 import com.insilenceclone.backend.common.jwt.JwtTokenProvider;
+import com.insilenceclone.backend.domain.cart.entity.Cart;
+import com.insilenceclone.backend.domain.cart.repository.CartRepository;
 import com.insilenceclone.backend.domain.user.dto.request.LoginRequestDto;
 import com.insilenceclone.backend.domain.user.dto.request.SignUpRequestDto;
 import com.insilenceclone.backend.domain.user.dto.response.TokenResponseDto;
@@ -23,6 +25,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final CartRepository cartRepository;
 
     // 회원가입
     @Transactional
@@ -52,7 +55,12 @@ public class UserService {
                 .address(request.address())
                 .build();
 
-        userRepository.save(user);
+        User savedUser = userRepository.save(user);
+
+        if(!cartRepository.existsByUserId(savedUser.getId())){
+            Cart cart = Cart.create(savedUser.getId());
+            cartRepository.save(cart);
+        }
     }
 
     // 로그인


### PR DESCRIPTION
## 💡 개요
> 장바구니 담기, 조회할 때 장바구니 없음 케이스를 최소화하기 위해 회원가입 시 자동 생성되도록 추가했습니다.

## 🔗 관련 이슈
Closes #45 

## 📝 작업 상세 내용
- [x] 회원가입 로직 마지막에 카트 생성 추가

## 📸 스크린샷 (Optional)
<img width="1298" height="518" alt="image" src="https://github.com/user-attachments/assets/80976b64-8969-4f5e-b463-d58d780589e3" />

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.