### PR TITLE
refactor(FE): 상품 주문 로직 코드 리팩토링

### DIFF
--- a/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     // user
     USER_LOGIN_ID_DUPLICATED(HttpStatus.BAD_REQUEST, "U001", "이미 사용 중인 아이디입니다."),
     USER_UNDER_MIN_AGE(HttpStatus.BAD_REQUEST, "U002", "만 14세 이상만 가입할 수 있습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U003", "사용자가 존재하지 않습니다."),
     
 
     // cart
@@ -31,7 +32,10 @@ public enum ErrorCode {
     CART_PRODUCT_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CA003", "productId는 필수입니다."),
     CART_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "CA004", "quantity는 1 이상이어야 합니다."),
     CART_NOT_FOUND(HttpStatus.NOT_FOUND, "C005", "장바구니가 없습니다."),
-    CART_EMPTY(HttpStatus.NOT_FOUND, "C006", "장바구니가 비어있습니다.");
+    CART_EMPTY(HttpStatus.NOT_FOUND, "C006", "장바구니가 비어있습니다."),
+
+    // Product
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "상품이 존재하지 않습니다.");
 
 
     private final HttpStatus status;

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/controller/OrderController.java
@@ -1,19 +1,20 @@
 package com.insilenceclone.backend.domain.order.controller;
 
 import com.insilenceclone.backend.common.response.ApiResponse;
-import com.insilenceclone.backend.domain.order.dto.request.OrderRequestDto;
+import com.insilenceclone.backend.domain.order.dto.request.OrderCartRequestDto;
+import com.insilenceclone.backend.domain.order.dto.request.OrderDirectRequestDto;
 import com.insilenceclone.backend.domain.order.service.OrderService;
 import com.insilenceclone.backend.domain.user.security.CustomUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@RequestMapping("api/v1/orders")
+@RestController
+@RequestMapping("/api/v1/orders")
 @RequiredArgsConstructor
 public class OrderController {
 
@@ -23,7 +24,7 @@ public class OrderController {
     @PostMapping("/direct")
     public ApiResponse<Long> createOrder(
             @AuthenticationPrincipal CustomUser userDetails,
-            @RequestBody @Valid OrderRequestDto requestDto
+            @RequestBody @Valid OrderDirectRequestDto requestDto
     ) {
         Long orderId = orderService.createOrder(userDetails.getId(), requestDto);
 
@@ -34,7 +35,7 @@ public class OrderController {
     @PostMapping("/cart")
     public ApiResponse<Long> createOrderFromCart(
             @AuthenticationPrincipal CustomUser userDetails,
-            @RequestBody @Valid OrderRequestDto requestDto
+            @RequestBody @Valid OrderCartRequestDto requestDto
     ) {
         Long orderId = orderService.createOrderFromCart(userDetails.getId(), requestDto);
 

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/dto/request/OrderCartRequestDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/dto/request/OrderCartRequestDto.java
@@ -1,0 +1,13 @@
+package com.insilenceclone.backend.domain.order.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OrderCartRequestDto extends OrderDeliveryDto {
+
+    @NotNull
+    private Long cartId;
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/dto/request/OrderDeliveryDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/dto/request/OrderDeliveryDto.java
@@ -1,19 +1,12 @@
 package com.insilenceclone.backend.domain.order.dto.request;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Getter
 @Setter
-// 주문할 때 받는 정보
-public class OrderRequestDto {
+public class OrderDeliveryDto {
 
     @NotBlank(message = "주소는 필수로 입력해야 합니다.")
     private String address;
@@ -27,23 +20,6 @@ public class OrderRequestDto {
     @NotBlank(message = "이메일은 필수로 입력해야 합니다.")
     private String email;
 
-    @NotEmpty(message = "주문 상품은 최소 1개 이상이어야 합니다.")
-    private List<OrderProductDto> products = new ArrayList<>();
-
-    private Long cartId;
-
     private String deliveryMessage;
 
-    // 추후 확장성 대비
-    private String paymentMethod;
-
-    @Getter
-    public static class OrderProductDto {
-
-        @NotNull
-        private Long productId;
-
-        @Min(1)
-        private int count;
-    }
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/dto/request/OrderDirectRequestDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/dto/request/OrderDirectRequestDto.java
@@ -1,0 +1,18 @@
+package com.insilenceclone.backend.domain.order.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OrderDirectRequestDto extends OrderDeliveryDto {
+
+    @NotNull(message = "상품 ID는 필수입니다.")
+    private Long productId;
+
+    @Min(value = 1, message = "수량은 최소 1개 있어야 합니다.")
+    private int count;
+
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/order/entity/Order.java
@@ -65,7 +65,7 @@ public class Order extends BaseTimeEntity {
         return this.totalPrice * MILEAGE_RATE / 100;
     }
 
-    public void updateTotalPrice(Long totalPrice) {
-        this.totalPrice = totalPrice;
+    public void addPrice(OrderItem orderItem) {
+        this.totalPrice += orderItem.calculateTotalPrice();
     }
 }


### PR DESCRIPTION
## 💡 개요
> `OrderService`의 주문 생성 로직에 존재하던 코드 중복을 제거하고 Bulk 조회로 DB 조회 성능 최적화

## 🔗 관련 이슈
Closes #44 

## 📝 작업 상세 내용
- [x] 공통 주문 로직 추출 및 통합 (`processOrder`) : 입력값을 Map 형태로 변환하여 처리
- [x] `OrderRequestDto` 를 삭제 후 `OrderDirectRequestDto`와 `OrderCartRequestDto`로 분리 및 컨트롤러 API 매개변수도 이에 맞추어 수정 (공통 배송 정보는 `OrderDeliveryDto` 로 상속 받게끔 하여 중복 제거)
- [x] 주문 로직에 상품을 한 번에 가져오게끔 최적화
- [x] 총 가격 계산 로직을 `Order` 엔티티로 이동

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항 및 참고 사항
> 테스트는 상품 DB가 들어오고 난 뒤 할 예정입니다.