### PR TITLE
feat(BE): 장바구니 조회 로직 (#52)

### DIFF
--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/controller/CartController.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/controller/CartController.java
@@ -2,15 +2,15 @@ package com.insilenceclone.backend.domain.cart.controller;
 
 import com.insilenceclone.backend.common.response.ApiResponse;
 import com.insilenceclone.backend.domain.cart.dto.request.CartItemAddRequestDto;
+import com.insilenceclone.backend.domain.cart.dto.response.CartItemResponseDto;
 import com.insilenceclone.backend.domain.cart.service.CartService;
 import com.insilenceclone.backend.domain.user.security.CustomUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/cart")
@@ -26,5 +26,11 @@ public class CartController {
     ) {
         cartService.addCartItem(user.getId(), request);
         return ApiResponse.success();
+    }
+
+    @GetMapping("/my")
+    public ApiResponse<List<CartItemResponseDto>> getMyCartItem(@AuthenticationPrincipal CustomUser user) {
+        List<CartItemResponseDto> myCart = cartService.viewMyCartItems(user.getId());
+        return ApiResponse.success(myCart);
     }
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/dto/response/CartItemResponseDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/dto/response/CartItemResponseDto.java
@@ -1,0 +1,10 @@
+package com.insilenceclone.backend.domain.cart.dto.response;
+
+public record CartItemResponseDto (
+        Long productId,
+        String name,
+        Long price,
+        String imageUrl,
+        int quantity
+){
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/repository/CartItemRepository.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/repository/CartItemRepository.java
@@ -11,6 +11,9 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
     // 장바구니에 담긴 아이템 전체 조회
     List<CartItem> findByCartId(Long cartId);
 
+    // 장바구니에 담긴 최신순으로 전체 조회
+    List<CartItem> findByCartIdOrderByUpdatedAtDesc(Long cartId);
+
     // 카트에 담을려는 상품이 이미 존재하는지 조회
     Optional<CartItem> findByCartIdAndProductId(Long cartId, Long productId);
 

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/service/CartService.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/service/CartService.java
@@ -3,14 +3,20 @@ package com.insilenceclone.backend.domain.cart.service;
 import com.insilenceclone.backend.common.exception.BusinessException;
 import com.insilenceclone.backend.common.exception.ErrorCode;
 import com.insilenceclone.backend.domain.cart.dto.request.CartItemAddRequestDto;
+import com.insilenceclone.backend.domain.cart.dto.response.CartItemResponseDto;
 import com.insilenceclone.backend.domain.cart.entity.Cart;
 import com.insilenceclone.backend.domain.cart.entity.CartItem;
 import com.insilenceclone.backend.domain.cart.repository.CartItemRepository;
 import com.insilenceclone.backend.domain.cart.repository.CartRepository;
 import com.insilenceclone.backend.domain.product.ProductRepositoryTemp;
+import com.insilenceclone.backend.domain.product.entity.Product;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -51,6 +57,48 @@ public class CartService {
         // 장바구니에 존재하는 상품일 경우 수량 증가
         // JPA dirty checking으로 update 반영
         cartItem.increaseQuantity(quantity);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CartItemResponseDto> viewMyCartItems(Long userId) {
+/*     1. userId로 cart 찾기 (없으면 빈 리스트)
+       2. cartId로 cartItem 리스트 조회(최근 담은순으로 정렬)
+       3. cartItem들에서 productIds 추출
+       4. findAllById(productIds)로 조회
+       5. Map<productId, Product>로 바꾸고 cartItem과 매칭해서 응답 DTO 리스트 만들기
+       */
+        Cart cart = cartRepository.findByUserId(userId)
+                .orElse(null);
+        if (cart == null) return List.of();  // 장바구니 자체가 없으면 비어있다고 처리
+
+        List<CartItem> cartItems = cartItemRepository.findByCartIdOrderByUpdatedAtDesc(cart.getId());
+
+        // 장바구니가 비었으면 빈 리스트 반환
+        if (cartItems.isEmpty()) return List.of();
+
+        // productId 추출
+        List<Long> productIds = cartItems.stream()
+                .map(CartItem::getProductId)
+                .distinct()
+                .toList();
+
+        List<Product> products = productRepositoryTemp.findAllById(productIds);
+
+        Map<Long, Product> productMap = products.stream()
+                .collect(Collectors.toMap(Product::getId, p -> p));
+
+        return cartItems.stream()
+                .map(ci -> {
+                    Product p = productMap.get(ci.getProductId());
+                    return new CartItemResponseDto(
+                            p.getId(),
+                            p.getName(),
+                            p.getPrice(),
+                            p.getImageUrl(),
+                            ci.getQuantity()
+                    );
+                })
+                .toList();
     }
 
 }


### PR DESCRIPTION
## 💡 개요
> 내 장바구니 조회 api를 구현했습니다.
최신 담긴 순으로 반환됩니다.

## 🔗 관련 이슈
Closes #52 

## 📝 작업 상세 내용
- [ ] 장바구니 아이템 조회 서비스 로직 구현
- [ ] 조회 응답 DTO 

## 📸 스크린샷 (Optional)
<img width="716" height="642" alt="스크린샷 2025-12-29 오전 1 40 39" src="https://github.com/user-attachments/assets/91b72d08-5df3-4c91-9857-90ab448f6512" />

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 상품 데이터가 없어 빈 장바구니일 경우 빈 리스트가 반환되는 테스트만 진행했습니다.