### PR TITLE
feat(BE) : 장바구니 삭제 서비스 (#54)

### DIFF
--- a/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
@@ -31,9 +31,10 @@ public enum ErrorCode {
     CART_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CA002", "cartId는 필수입니다."),
     CART_PRODUCT_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CA003", "productId는 필수입니다."),
     CART_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "CA004", "quantity는 1 이상이어야 합니다."),
-    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "C005", "장바구니가 없습니다."),
-    CART_EMPTY(HttpStatus.NOT_FOUND, "C006", "장바구니가 비어있습니다."),
-
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "CA005", "장바구니가 없습니다."),
+    CART_EMPTY(HttpStatus.NOT_FOUND, "CA006", "장바구니가 비어있습니다."),
+    CART_ITEM_NOT_SELECTED(HttpStatus.BAD_REQUEST, "CA007", "선택된 상품이 없습니다."),
+    CART_ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST, "CA008", "장바구니에 해당 상품이 없습니다."),
     // Product
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "상품이 존재하지 않습니다."),
 

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/controller/CartController.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/controller/CartController.java
@@ -2,6 +2,7 @@ package com.insilenceclone.backend.domain.cart.controller;
 
 import com.insilenceclone.backend.common.response.ApiResponse;
 import com.insilenceclone.backend.domain.cart.dto.request.CartItemAddRequestDto;
+import com.insilenceclone.backend.domain.cart.dto.request.CartItemsDeleteRequestDto;
 import com.insilenceclone.backend.domain.cart.dto.response.CartItemResponseDto;
 import com.insilenceclone.backend.domain.cart.service.CartService;
 import com.insilenceclone.backend.domain.user.security.CustomUser;
@@ -32,5 +33,12 @@ public class CartController {
     public ApiResponse<List<CartItemResponseDto>> getMyCartItem(@AuthenticationPrincipal CustomUser user) {
         List<CartItemResponseDto> myCart = cartService.viewMyCartItems(user.getId());
         return ApiResponse.success(myCart);
+    }
+
+    @PostMapping("/items/delete")
+    public ApiResponse<Void> deleteCartItems(@AuthenticationPrincipal CustomUser user,
+                                             @Valid @RequestBody CartItemsDeleteRequestDto request) {
+        cartService.deleteItems(user.getId(),request);
+        return ApiResponse.success();
     }
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/dto/request/CartItemsDeleteRequestDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/dto/request/CartItemsDeleteRequestDto.java
@@ -1,0 +1,13 @@
+package com.insilenceclone.backend.domain.cart.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record CartItemsDeleteRequestDto(
+
+        @NotEmpty(message = "선택된 상품이 없습니다.")
+        List<@NotNull(message = "cartItem은 null일 수 없습니다.") Long> cartItemIds
+) {
+}

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/repository/CartItemRepository.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/repository/CartItemRepository.java
@@ -3,6 +3,7 @@ package com.insilenceclone.backend.domain.cart.repository;
 import com.insilenceclone.backend.domain.cart.entity.CartItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+
 import java.util.List;
 import java.util.Optional;
 
@@ -17,8 +18,7 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
     // 카트에 담을려는 상품이 이미 존재하는지 조회
     Optional<CartItem> findByCartIdAndProductId(Long cartId, Long productId);
 
-    // 특정 상품 삭제
-    void deleteByCartIdAndProductId(Long cartId, Long productId);
-    // 전체 상품 삭제
-    void deleteByCartId(Long cartId);
+    List<CartItem> findByCartIdAndIdIn(Long userId, List<Long> cartItemIds);
+
+    void deleteByCartIdAndIdIn(Long cartId, List<Long> cartItemIds);
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/service/CartService.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/service/CartService.java
@@ -3,6 +3,7 @@ package com.insilenceclone.backend.domain.cart.service;
 import com.insilenceclone.backend.common.exception.BusinessException;
 import com.insilenceclone.backend.common.exception.ErrorCode;
 import com.insilenceclone.backend.domain.cart.dto.request.CartItemAddRequestDto;
+import com.insilenceclone.backend.domain.cart.dto.request.CartItemsDeleteRequestDto;
 import com.insilenceclone.backend.domain.cart.dto.response.CartItemResponseDto;
 import com.insilenceclone.backend.domain.cart.entity.Cart;
 import com.insilenceclone.backend.domain.cart.entity.CartItem;
@@ -101,4 +102,23 @@ public class CartService {
                 .toList();
     }
 
+    public void deleteItems(Long userId, CartItemsDeleteRequestDto request) {
+
+        /*
+        * 1. 유저의 장바구니를 찾는다.
+        * 2. userId, cartItemId 를 통해 삭제해야할 list를 찾음
+        * 3. 삭제*/
+        Cart cart = cartRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CART_NOT_FOUND));
+
+        List<Long> ids = request.cartItemIds().stream().distinct().toList();
+
+        List<CartItem> cartItems = cartItemRepository.findByCartIdAndIdIn(cart.getId(),ids);
+
+        if(ids.size()!=cartItems.size()){
+            throw new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND);
+        }
+
+        cartItemRepository.deleteByCartIdAndIdIn(cart.getId(), ids);
+    }
 }


### PR DESCRIPTION
## 💡 개요
>  장바구니에서 선택한 상품(CartItem)을 hard delete로 삭제하는 API를 구현했습니다.

## 🔗 관련 이슈
Closes #54 

## 📝 작업 상세 내용
- [ ] 장바구니 상품 삭제 API 엔드포인트 추가 (선택 삭제 지원)
- [ ] 요청 값 검증 및 예외 처리(ErrorCode/BusinessException) 적용
- [ ] 삭제 후 정상 응답 반환 및 기본 동작 테스트

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [ ] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?
- [ ] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
테스트는 상품db 추가 후 할 예정입니다