### PR TITLE
feat(BE): 장바구니 수량 변경 서비스 (#60)

### DIFF
--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/controller/CartController.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/controller/CartController.java
@@ -41,4 +41,22 @@ public class CartController {
         cartService.deleteItems(user.getId(),request);
         return ApiResponse.success();
     }
+
+    @PatchMapping("/{cartItemId}/increase")
+    public ApiResponse<Void> increaseQuantity(
+            @AuthenticationPrincipal CustomUser user,
+            @PathVariable Long cartItemId
+    ) {
+        cartService.increaseQuantity(user.getId(), cartItemId);
+        return ApiResponse.success();
+    }
+
+    @PatchMapping("/{cartItemId}/decrease")
+    public ApiResponse<Void> decreaseQuantity(
+            @AuthenticationPrincipal CustomUser user,
+            @PathVariable Long cartItemId
+    ) {
+        cartService.decreaseQuantity(user.getId(), cartItemId);
+        return ApiResponse.success();
+    }
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/entity/CartItem.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/entity/CartItem.java
@@ -48,4 +48,11 @@ public class CartItem extends BaseTimeEntity {
         if (amount <= 0) {throw new BusinessException(ErrorCode.CART_QUANTITY_INVALID);}
         this.quantity += amount;
     }
+
+    public void decreaseQuantity() {
+        if (this.quantity <= 1) {
+            return; // 최소 1 유지: 변경 없음
+        }
+        this.quantity -= 1;
+    }
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/repository/CartItemRepository.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/repository/CartItemRepository.java
@@ -21,4 +21,6 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
     List<CartItem> findByCartIdAndIdIn(Long userId, List<Long> cartItemIds);
 
     void deleteByCartIdAndIdIn(Long cartId, List<Long> cartItemIds);
+
+    Optional<CartItem> findByIdAndCartId(Long cartItemId, Long cartId);
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/service/CartService.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/service/CartService.java
@@ -102,6 +102,7 @@ public class CartService {
                 .toList();
     }
 
+    @Transactional
     public void deleteItems(Long userId, CartItemsDeleteRequestDto request) {
 
         /*
@@ -120,5 +121,28 @@ public class CartService {
         }
 
         cartItemRepository.deleteByCartIdAndIdIn(cart.getId(), ids);
+    }
+
+    @Transactional
+    public void increaseQuantity(Long userId, Long cartItemId) {
+
+        Cart cart = cartRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CART_NOT_FOUND));
+
+        CartItem cartItem = cartItemRepository.findByIdAndCartId(cartItemId,cart.getId())
+                .orElseThrow(()-> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
+
+        cartItem.increaseQuantity(1);
+    }
+
+    @Transactional
+    public void decreaseQuantity(Long userId, Long cartItemId) {
+        Cart cart = cartRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CART_NOT_FOUND));
+
+        CartItem cartItem = cartItemRepository.findByIdAndCartId(cartItemId,cart.getId())
+                .orElseThrow(()-> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
+
+        cartItem.decreaseQuantity();
     }
 }

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/service/CartService.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/service/CartService.java
@@ -109,8 +109,7 @@ public class CartService {
         * 1. 유저의 장바구니를 찾는다.
         * 2. userId, cartItemId 를 통해 삭제해야할 list를 찾음
         * 3. 삭제*/
-        Cart cart = cartRepository.findByUserId(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.CART_NOT_FOUND));
+        Cart cart = getCartOrThrow(userId);
 
         List<Long> ids = request.cartItemIds().stream().distinct().toList();
 
@@ -126,23 +125,30 @@ public class CartService {
     @Transactional
     public void increaseQuantity(Long userId, Long cartItemId) {
 
-        Cart cart = cartRepository.findByUserId(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.CART_NOT_FOUND));
-
-        CartItem cartItem = cartItemRepository.findByIdAndCartId(cartItemId,cart.getId())
-                .orElseThrow(()-> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
+        Cart cart = getCartOrThrow(userId);
+        CartItem cartItem = getCartItemOrThrow(cartItemId,cart.getId());
 
         cartItem.increaseQuantity(1);
     }
 
     @Transactional
     public void decreaseQuantity(Long userId, Long cartItemId) {
-        Cart cart = cartRepository.findByUserId(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.CART_NOT_FOUND));
-
-        CartItem cartItem = cartItemRepository.findByIdAndCartId(cartItemId,cart.getId())
-                .orElseThrow(()-> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
+        Cart cart = getCartOrThrow(userId);
+        CartItem cartItem = getCartItemOrThrow(cartItemId,cart.getId());
 
         cartItem.decreaseQuantity();
     }
+
+    private Cart getCartOrThrow(Long userId){
+
+        return cartRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CART_NOT_FOUND));
+    }
+
+    private CartItem getCartItemOrThrow(Long cartItemId, Long cartId){
+
+        return cartItemRepository.findByIdAndCartId(cartItemId,cartId)
+                .orElseThrow(()-> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
+    }
+
 }


### PR DESCRIPTION
## 💡 개요
> 장바구니에 담아놓은 상품의 수량을 증가 또는 감소 시킨다.

## 🔗 관련 이슈
Closes #60 

## 📝 작업 상세 내용
- [ ] 장바구니의 수량을 1 감소시키는 메서드를 추가했으며 1보다 수량이 작아질 경우 바로 return하여 값을 변경하지 않는다.
- [ ] 장바구니 수량 증가/감소 서비스 로직 구현
- [ ] 장바구니 수량 증가/감소 api 작성

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [ ] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?
- [ ] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 추후 수량의 개수를 max 5로 줘 refactor 할 예정입니다.