### PR TITLE
fix(BE): CartItem 응답DTO 수정 및 수량 제한 추가(#108)

### DIFF
--- a/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/insilenceclone/backend/common/exception/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
     CART_USER_ID_REQUIRED(HttpStatus.BAD_REQUEST,"CA001","userId는 필수입니다."),
     CART_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CA002", "cartId는 필수입니다."),
     CART_PRODUCT_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CA003", "productId는 필수입니다."),
-    CART_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "CA004", "quantity는 1 이상이어야 합니다."),
+    CART_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "CA004", "quantity는 1이상 재고 이하여야합니다."),
     CART_NOT_FOUND(HttpStatus.NOT_FOUND, "CA005", "장바구니가 없습니다."),
     CART_EMPTY(HttpStatus.NOT_FOUND, "CA006", "장바구니가 비어있습니다."),
     CART_ITEM_NOT_SELECTED(HttpStatus.BAD_REQUEST, "CA007", "선택된 상품이 없습니다."),

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/controller/CartController.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/controller/CartController.java
@@ -42,7 +42,7 @@ public class CartController {
         return ApiResponse.success();
     }
 
-    @PatchMapping("/{cartItemId}/increase")
+    @PostMapping("/{cartItemId}/increase")
     public ApiResponse<Void> increaseQuantity(
             @AuthenticationPrincipal CustomUser user,
             @PathVariable Long cartItemId
@@ -51,7 +51,7 @@ public class CartController {
         return ApiResponse.success();
     }
 
-    @PatchMapping("/{cartItemId}/decrease")
+    @PostMapping("/{cartItemId}/decrease")
     public ApiResponse<Void> decreaseQuantity(
             @AuthenticationPrincipal CustomUser user,
             @PathVariable Long cartItemId

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/dto/response/CartItemResponseDto.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/dto/response/CartItemResponseDto.java
@@ -1,6 +1,7 @@
 package com.insilenceclone.backend.domain.cart.dto.response;
 
 public record CartItemResponseDto (
+        Long cartItemId,
         Long productId,
         String name,
         Long price,

--- a/backend/src/main/java/com/insilenceclone/backend/domain/cart/service/CartService.java
+++ b/backend/src/main/java/com/insilenceclone/backend/domain/cart/service/CartService.java
@@ -92,6 +92,7 @@ public class CartService {
                 .map(ci -> {
                     Product p = productMap.get(ci.getProductId());
                     return new CartItemResponseDto(
+                            ci.getId(),
                             p.getId(),
                             p.getName(),
                             p.getPrice(),


### PR DESCRIPTION
## 💡 개요
> 프론트엔드 장바구니 페이지 연동을 위한 응답 DTO 수정 밀 상품 수량 제한 비즈니스 로직 구현

## 🔗 관련 이슈
Closes #108 

## 📝 작업 상세 내용
- [ ] CartItemResponseDto 필드 추가
- [ ] 장바구니 수량 제한 정책 적용(5개)
- [ ] CartService 로직 수정

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [ ] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?
- [ ] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항