### PR TITLE
feat(fe): 라우터 가드 추가 (#122)

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,6 +3,7 @@ import { mainRoutes } from "./routes/main.routes.js"
 import { memberRoutes } from "./routes/member.routes.js";
 import { orderRoutes } from "./routes/order.routes.js";
 import { cartRoutes } from './routes/cart.routes.js'
+import { getToken } from '../utils/token.js'
 
 // TODO: router import
 
@@ -15,6 +16,34 @@ const router = createRouter({
         ...orderRoutes,
         ...cartRoutes,
     ]
+})
+
+// 🔐 전역 라우터 가드
+router.beforeEach((to, from, next) => {
+    const token = getToken()
+
+    const requiresAuth = to.matched.some(
+        route => route.meta.requiresAuth
+    )
+
+    const guestOnly = to.matched.some(
+        route => route.meta.guestOnly
+    )
+
+    // 1️⃣ 로그인 필요한 페이지인데 토큰 없음
+    if (requiresAuth && !token) {
+        alert('로그인이 필요합니다.')
+        next('/login')
+        return
+    }
+
+    // 2️⃣ 이미 로그인 했는데 로그인/회원가입 페이지 접근
+    if (guestOnly && token) {
+        next('/') // 또는 '/cart'
+        return
+    }
+
+    next()
 })
 
 export default router

--- a/frontend/src/router/routes/cart.routes.js
+++ b/frontend/src/router/routes/cart.routes.js
@@ -6,5 +6,6 @@ export const cartRoutes = [
         path: '/cart',
         name: 'cart',
         component: CartView,
+        meta: { requiresAuth: true },
     },
 ]

--- a/frontend/src/router/routes/member.routes.js
+++ b/frontend/src/router/routes/member.routes.js
@@ -11,12 +11,14 @@ export const memberRoutes = [
         path: '/login',
         name: 'Login',
         component: LoginView,
+        meta: { guestOnly: true },
     },
     // 회원가입 1단계: 약관
     {
         path: '/signup/terms',
         name: 'SignupTerms',
         component: SignupTermsView,
+        meta: { guestOnly: true },
     },
 
     // 회원가입 2단계: 정보 입력
@@ -24,6 +26,7 @@ export const memberRoutes = [
         path: '/signup',
         name: 'Signup',
         component: SignupView,
+        meta: { guestOnly: true },
     },
 
     // 마이페이지
@@ -31,6 +34,7 @@ export const memberRoutes = [
         path: '/mypage',
         name: 'MyPage',
         component: MyPage,
+        meta: { requiresAuth: true },
     },
 
     // 주문조회
@@ -38,6 +42,7 @@ export const memberRoutes = [
         path: '/mypage/orders',
         name: 'OrderList',
         component: OrderListPage,
+        meta: { requiresAuth: true },
     },
 
     // 회원정보 수정
@@ -45,5 +50,6 @@ export const memberRoutes = [
         path: '/mypage/profile',
         name: 'ProfileEdit',
         component: ProfileEditPage,
+        meta: { requiresAuth: true },
     },
 ]

--- a/frontend/src/router/routes/order.routes.js
+++ b/frontend/src/router/routes/order.routes.js
@@ -4,6 +4,7 @@ export const orderRoutes = [
     {
         path: '/order',
         name: 'OrderSheet',
-        component: OrderSheet
+        component: OrderSheet,
+        meta: { requiresAuth: true },
     }
 ];


### PR DESCRIPTION
## 💡 개요
> 로그인 상태에 따라 페이지 접근을 제어하는 Vue Router 전역 가드를 구현했습니다.
인증이 필요한 페이지와 비로그인 전용 페이지를 구분하여 사용자 접근 흐름을 개선했습니다.

## 🔗 관련 이슈
Closes #122 

## 📝 작업 상세 내용
- [ ] 인증이 필요한 페이지에 meta.requiresAuth 설정 추가
- [ ] 비로그인 사용자만 접근 가능한 페이지에 meta.guestOnly 설정 추가
- [ ] Vue Router 전역 가드를 통해 로그인 상태에 따른 페이지 접근 제어 구현
- [ ] 비로그인 상태 접근 시 로그인 페이지로 리다이렉트 처리 

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [ ] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?
- [ ] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.