### PR TITLE
feat(FE): 결제 및 주문 완료 View 작성 (#115)

### DIFF
--- a/frontend/src/components/order/ShippingForm.vue
+++ b/frontend/src/components/order/ShippingForm.vue
@@ -276,10 +276,41 @@
                  </div>
             </div>
 
-            <!-- 4. Applied Amount -->
+     <!-- 4. Applied Amount -->
             <div class="total-discount-wrapped">
                 <div class="row-label">적용금액</div>
                 <span class="price-text font-bold text-blue" style="font-size: 11px;">-KRW {{ totalDiscount.toLocaleString() }}</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- [SECTION 4] Payment Info (결제정보) -->
+    <div class="payment-info-section-container">
+        <div class="form-box" style="border-top: none;">
+             <!-- Section Title -->
+            <div class="section-title no-border-bottom">
+                <h3>결제정보</h3>
+                <span class="toggle-icon">^</span>
+            </div>
+
+            <!-- Payment Summary Rows -->
+            <div class="payment-summary-rows" style="padding: 0 20px 20px 20px;">
+                <div class="summary-row" style="display: flex; justify-content: space-between; margin-bottom: 15px; font-size: 11px;">
+                    <span style="color: #333;">주문상품</span>
+                    <span class="font-bold">KRW {{ totalProductPrice.toLocaleString() }}</span>
+                </div>
+                <div class="summary-row" style="display: flex; justify-content: space-between; margin-bottom: 15px; font-size: 11px;">
+                    <span style="color: #333;">배송비</span>
+                    <span class="font-bold">+KRW {{ shippingFee.toLocaleString() }}</span>
+                </div>
+                <div class="summary-row" style="display: flex; justify-content: space-between; margin-bottom: 30px; font-size: 11px;">
+                    <span style="color: #333;">할인/부가결제</span>
+                    <span class="text-red font-bold" style="color: #d9534f;">-KRW {{ totalDiscount.toLocaleString() }}</span>
+                </div>
+                 <div class="summary-row final-row" style="display: flex; justify-content: space-between; padding-top: 20px; border-top: 1px solid #eee; font-size: 12px; font-weight: 700;">
+                    <span>최종 결제 금액</span>
+                    <span style="font-size: 13px;">KRW {{ finalPaymentAmount.toLocaleString() }}</span>
+                </div>
             </div>
         </div>
     </div>
@@ -446,6 +477,14 @@ const totalDiscount = computed(() => {
     return miles + deposit;
 });
 
+const totalProductPrice = computed(() => {
+    return products.value.reduce((sum, p) => sum + (p.price * p.quantity), 0);
+});
+
+const finalPaymentAmount = computed(() => {
+    return totalProductPrice.value + shippingFee.value - totalDiscount.value;
+});
+
 onMounted(() => {
   fetchUserInfo();
   fetchCartItems();
@@ -491,6 +530,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin-bottom: 15px;
 }
 
 .section-title h3 {
@@ -891,7 +931,7 @@ onMounted(() => {
 .horizontal-row.top-align {
     align-items: flex-start;
     padding-top: 30px; /* [수정] 15px -> 10px */
-    padding-bottom: 30px;
+    padding-bottom: 10px;
 }
 
 .horizontal-row.top-align .row-label {
@@ -982,6 +1022,7 @@ onMounted(() => {
     justify-content: space-between;
     align-items: center;
     width: 100%;
+
 }
 
 .mt-2 {

--- a/frontend/src/components/order/ShippingForm.vue
+++ b/frontend/src/components/order/ShippingForm.vue
@@ -328,37 +328,39 @@
                 <div class="payment-method-header" style="padding: 5px 0; font-size: 11px; font-weight: bold; margin-bottom: 25px;">
                     결제수단 선택
                 </div>
-                
-                <!-- Radio List -->
-                <div class="radio-list">
-                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'card' }">
-                        <input type="radio" value="card" v-model="paymentMethod" name="payment_method">
-                        <span>카드 (CARD)</span>
-                    </label>
-                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'escrow' }">
-                        <input type="radio" value="escrow" v-model="paymentMethod" name="payment_method">
-                        <span>에스크로(실시간 계좌이체)</span>
-                    </label>
-                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'transfer' }">
-                        <input type="radio" value="transfer" v-model="paymentMethod" name="payment_method">
-                        <span>무통장 입금 (transfer)</span>
-                    </label>
-                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'payco' }">
-                        <input type="radio" value="payco" v-model="paymentMethod" name="payment_method">
-                        <span>페이코(간편결제)</span>
-                    </label>
-                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'samsung' }">
-                        <input type="radio" value="samsung" v-model="paymentMethod" name="payment_method">
-                        <span>삼성페이</span>
-                    </label>
-                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'kakaopay' }">
-                        <input type="radio" value="kakaopay" v-model="paymentMethod" name="payment_method">
-                        <span>카카오페이(간편결제)</span>
-                    </label>
-                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'toss' }">
-                        <input type="radio" value="toss" v-model="paymentMethod" name="payment_method">
-                        <span>토스</span>
-                    </label>
+                <!-- Table Wrapper -->
+                <div class="payment-table-wrapper" style="border: 1px solid #eee;">
+                    <!-- Radio List -->
+                    <div class="radio-list">
+                        <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'card' }">
+                            <input type="radio" value="card" v-model="paymentMethod" name="payment_method">
+                            <span>카드 (CARD)</span>
+                        </label>
+                        <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'escrow' }">
+                            <input type="radio" value="escrow" v-model="paymentMethod" name="payment_method">
+                            <span>에스크로(실시간 계좌이체)</span>
+                        </label>
+                        <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'transfer' }">
+                            <input type="radio" value="transfer" v-model="paymentMethod" name="payment_method">
+                            <span>무통장 입금 (transfer)</span>
+                        </label>
+                        <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'payco' }">
+                            <input type="radio" value="payco" v-model="paymentMethod" name="payment_method">
+                            <span>페이코(간편결제)</span>
+                        </label>
+                        <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'samsung' }">
+                            <input type="radio" value="samsung" v-model="paymentMethod" name="payment_method">
+                            <span>삼성페이</span>
+                        </label>
+                        <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'kakaopay' }">
+                            <input type="radio" value="kakaopay" v-model="paymentMethod" name="payment_method">
+                            <span>카카오페이(간편결제)</span>
+                        </label>
+                        <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'toss' }">
+                            <input type="radio" value="toss" v-model="paymentMethod" name="payment_method">
+                            <span>토스</span>
+                        </label>
+                    </div>
                 </div>
             </div>
         </div>
@@ -1085,6 +1087,9 @@ onMounted(() => {
     cursor: pointer;
     font-size: 11px; /* 폰트 사이즈 조정 */
     color: #888; /* 기본 컬러 연하게 */
+}
+.payment-radio-item:last-child {
+    border-bottom: none;
 }
 
 /* Hide default radio input */

--- a/frontend/src/components/order/ShippingForm.vue
+++ b/frontend/src/components/order/ShippingForm.vue
@@ -168,11 +168,11 @@
         </div>
       </div>
 
-      <div class="save-checkbox">
-        <label class="checkbox-label">
-          <input type="checkbox" />
-          <span class="custom-checkbox"></span>
-          기본 배송지로 저장
+      <div class="save-checkbox" style="margin-top: 0px; padding-bottom: 20px; padding-left: 20px;">
+        <label class="checkbox-label" style="display: flex; align-items: center; cursor: pointer;">
+          <input type="checkbox" class="custom-checkbox-input" />
+          <span class="custom-checkbox-box"></span>
+          <span style="font-size: 11px; color: #353535; font-weight: 400;">기본 배송지로 저장</span>
         </label>
       </div>
     </div>
@@ -362,9 +362,25 @@
                         </label>
                     </div>
                 </div>
+
+                <!-- Payment Method Help Text -->
+                <div class="payment-help-box" v-if="currentHelpText.length > 0">
+                    <ul class="help-list">
+                        <li v-for="(text, index) in currentHelpText" :key="index" v-html="text"></li>
+                    </ul>
+            </div> <!-- Close payment-help-box -->
+
+            <!-- Save Payment Info Checkbox -->
+            <div class="save-payment-info" style="margin-top: 20px; padding: 0;">
+                <label class="checkbox-label" style="display: flex; align-items: center; cursor: pointer;">
+                    <input type="checkbox" v-model="savePaymentInfo" class="custom-checkbox-input">
+                    <span class="custom-checkbox-box"></span>
+                    <span style="font-size: 11px; color: #353535; font-weight: 400;">결제수단과 입력정보를 다음에도 사용</span>
+                </label>
             </div>
         </div>
     </div>
+</div>
 
   </div>
 </template>
@@ -520,8 +536,46 @@ const couponCount = ref(0); // 기본값 0
 const mileageBalance = ref(0); // 기본값 0
 const depositBalance = ref(0); // 기본값 0
 const usedMileage = ref(''); // [수정] 기본값 0 -> 공란
-const usedDeposit = ref(''); // [수정] 기본값 0 -> 공란
+const usedDeposit = ref(0); // Changed from '' to 0 to avoid redeclaration and ensure syntactic correctness
 const paymentMethod = ref('card'); // 기본값 카드
+const savePaymentInfo = ref(true); // Save Payment Info Checkbox (Default: true)
+
+/* Helper Text Logic */
+const helpTextMap = {
+    card: [
+        "최소 결제 가능 금액은 총 결제금액에서 배송비를 제외한 금액입니다.",
+        "소액 결제의 경우 PG사 정책에 따라 결제 금액 제한이 있을 수 있습니다."
+    ],
+    escrow: [
+        "최소 결제 가능 금액은 총 결제금액에서 배송비를 제외한 금액입니다.",
+        "소액 결제의 경우 PG사 정책에 따라 결제 금액 제한이 있을 수 있습니다."
+    ],
+    transfer: [
+        "최소 결제 가능 금액은 총 결제금액에서 배송비를 제외한 금액입니다.",
+        "소액 결제의 경우 PG사 정책에 따라 결제 금액 제한이 있을 수 있습니다."
+    ],
+    samsung: [
+        "최소 결제 가능 금액은 총 결제금액에서 배송비를 제외한 금액입니다.",
+        "소액 결제의 경우 PG사 정책에 따라 결제 금액 제한이 있을 수 있습니다."
+    ],
+    payco: [
+        "페이코(<a href='//www.payco.com' target='_blank'>www.payco.com</a>)에 회원가입 후, 최초 1회 카드 및 계좌 정보를 등록하셔야 사용 가능합니다."
+    ],
+    kakaopay: [
+        "카카오톡 앱을 설치한 후, 최초 1회 카드정보를 등록하셔야 사용 가능합니다.",
+        "인터넷 익스플로러는 8 이상에서만 결제 가능합니다.",
+        "카카오머니로 결제 시, 현금영수증 발급은 ㈜카카오페이에서 발급가능합니다."
+    ],
+    toss: [
+        "토스는 간편하게 지문 또는 비밀번호만으로 결제할 수 있는 빠르고 편리한 간편 결제 서비스입니다.",
+        "토스 결제 후 취소/반품 등이 발생할 경우 토스를 통한 신용카드 취소/토스머니 환불이 이루어집니다.",
+        "토스 이용가능 결제수단 : 국내 발행 신용/체크카드, 토스머니"
+    ]
+};
+
+const currentHelpText = computed(() => {
+    return helpTextMap[paymentMethod.value] || [];
+});
 
 const totalDiscount = computed(() => {
     const miles = Number(usedMileage.value) || 0;
@@ -924,6 +978,40 @@ onMounted(() => {
     border-top: none;
 }
 
+/* New style for payment method section title */
+.payment-method-section-container .section-title {
+    margin-top: 0 !important;
+}
+
+/* Payment Help Box */
+.payment-help-box {
+    margin-top: 20px;
+    padding: 20px;
+    border: 1px solid #e8e8e8;
+    background-color: #fbfbfb; /* Matching the reference gray */
+    color: #707070;
+    font-size: 11px;
+}
+
+.help-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.help-list li {
+    padding-left: 10px;
+    position: relative;
+    line-height: 1.8;
+}
+
+.help-list li::before {
+    content: "-";
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
 .justify-between {
     justify-content: space-between;
 }
@@ -1130,6 +1218,41 @@ onMounted(() => {
 .flex-row {
     display: flex;
     flex-direction: row;
+}
+
+/* Custom Checkbox Styling */
+.custom-checkbox-input {
+    display: none; /* Hide default checkbox */
+}
+
+.custom-checkbox-box {
+    width: 20px;
+    height: 20px;
+    background-color: #ddd; /* Light gray usually, or #e0e0e0 */
+    border-radius: 4px; /* Rounded corners */
+    margin-right: 8px;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s;
+}
+
+/* Checked State */
+.custom-checkbox-input:checked + .custom-checkbox-box {
+    background-color: #ddd; /* Keep gray or change if needed based on reference, looking at image it seems gray with white check */
+}
+
+/* Checkmark Icon (CSS) */
+.custom-checkbox-input:checked + .custom-checkbox-box::after {
+    content: '';
+    width: 6px;
+    height: 10px;
+    border: solid white;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+    position: absolute;
+    top: 3px;
 }
 
 </style>

--- a/frontend/src/components/order/ShippingForm.vue
+++ b/frontend/src/components/order/ShippingForm.vue
@@ -276,24 +276,20 @@
                  </div>
             </div>
 
-     <!-- 4. Applied Amount -->
+     <!-- 4. 적용금액 -->
             <div class="total-discount-wrapped">
                 <div class="row-label">적용금액</div>
                 <span class="price-text font-bold text-blue" style="font-size: 11px;">-KRW {{ totalDiscount.toLocaleString() }}</span>
             </div>
-        </div>
-    </div>
 
-    <!-- [SECTION 4] Payment Info (결제정보) -->
-    <div class="payment-info-section-container">
-        <div class="form-box" style="border-top: none;">
-             <!-- Section Title -->
-            <div class="section-title no-border-bottom">
+            <!-- [섹션 4] 결제정보 -->
+            <!-- 섹션 타이틀 -->
+            <div class="section-title no-border-bottom" style="border-top: 1px solid #ddd; margin-top: 0;">
                 <h3>결제정보</h3>
                 <span class="toggle-icon">^</span>
             </div>
 
-            <!-- Payment Summary Rows -->
+            <!-- 결제 요약 정보 -->
             <div class="payment-summary-rows" style="padding: 0 20px 20px 20px;">
                 <div class="summary-row" style="display: flex; justify-content: space-between; margin-bottom: 15px; font-size: 11px;">
                     <span style="color: #333;">주문상품</span>
@@ -312,14 +308,10 @@
                     <span style="font-size: 13px;">KRW {{ finalPaymentAmount.toLocaleString() }}</span>
                 </div>
             </div>
-        </div>
-    </div>
 
-    <!-- [SECTION 5] Payment Method (결제수단) -->
-    <div class="payment-method-section-container">
-        <div class="form-box" style="border-top: none;">
-             <!-- Section Title -->
-            <div class="section-title no-border-bottom">
+            <!-- [섹션 5] 결제수단 -->
+            <!-- 섹션 타이틀 -->
+            <div class="section-title no-border-bottom" style="border-top: 1px solid #ddd; margin-top: 0;">
                 <h3>결제수단</h3>
                 <span class="toggle-icon">^</span>
             </div>
@@ -630,6 +622,13 @@ const handleSubmit = async () => {
     if (!form.receiverName || !form.phone2 || !form.phone3 || !form.detailAddress) {
         alert("배송지 정보를 모두 입력해주세요.");
         return;
+    }
+
+    // 2. 결제 확인 대화상자
+    const formattedAmount = finalPaymentAmount.value.toLocaleString();
+    const confirmMessage = `총 결제 금액: KRW ${formattedAmount}\n\n결제하시겠습니까?`;
+    if (!confirm(confirmMessage)) {
+        return; // 사용자가 '아니오'를 선택한 경우
     }
 
     // 2. Prepare Data

--- a/frontend/src/components/order/ShippingForm.vue
+++ b/frontend/src/components/order/ShippingForm.vue
@@ -315,6 +315,55 @@
         </div>
     </div>
 
+    <!-- [SECTION 5] Payment Method (결제수단) -->
+    <div class="payment-method-section-container">
+        <div class="form-box" style="border-top: none;">
+             <!-- Section Title -->
+            <div class="section-title no-border-bottom">
+                <h3>결제수단</h3>
+                <span class="toggle-icon">^</span>
+            </div>
+
+            <div class="payment-methods-list" style="padding: 0 20px 20px 20px;">
+                <div class="payment-method-header" style="padding: 5px 0; font-size: 11px; font-weight: bold; margin-bottom: 25px;">
+                    결제수단 선택
+                </div>
+                
+                <!-- Radio List -->
+                <div class="radio-list">
+                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'card' }">
+                        <input type="radio" value="card" v-model="paymentMethod" name="payment_method">
+                        <span>카드 (CARD)</span>
+                    </label>
+                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'escrow' }">
+                        <input type="radio" value="escrow" v-model="paymentMethod" name="payment_method">
+                        <span>에스크로(실시간 계좌이체)</span>
+                    </label>
+                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'transfer' }">
+                        <input type="radio" value="transfer" v-model="paymentMethod" name="payment_method">
+                        <span>무통장 입금 (transfer)</span>
+                    </label>
+                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'payco' }">
+                        <input type="radio" value="payco" v-model="paymentMethod" name="payment_method">
+                        <span>페이코(간편결제)</span>
+                    </label>
+                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'samsung' }">
+                        <input type="radio" value="samsung" v-model="paymentMethod" name="payment_method">
+                        <span>삼성페이</span>
+                    </label>
+                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'kakaopay' }">
+                        <input type="radio" value="kakaopay" v-model="paymentMethod" name="payment_method">
+                        <span>카카오페이(간편결제)</span>
+                    </label>
+                    <label class="payment-radio-item" :class="{ 'selected': paymentMethod === 'toss' }">
+                        <input type="radio" value="toss" v-model="paymentMethod" name="payment_method">
+                        <span>토스</span>
+                    </label>
+                </div>
+            </div>
+        </div>
+    </div>
+
   </div>
 </template>
 
@@ -470,6 +519,7 @@ const mileageBalance = ref(0); // 기본값 0
 const depositBalance = ref(0); // 기본값 0
 const usedMileage = ref(''); // [수정] 기본값 0 -> 공란
 const usedDeposit = ref(''); // [수정] 기본값 0 -> 공란
+const paymentMethod = ref('card'); // 기본값 카드
 
 const totalDiscount = computed(() => {
     const miles = Number(usedMileage.value) || 0;
@@ -531,6 +581,7 @@ onMounted(() => {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 15px;
+  margin-top: 10px;
 }
 
 .section-title h3 {
@@ -1023,6 +1074,33 @@ onMounted(() => {
     align-items: center;
     width: 100%;
 
+}
+
+/* Payment Method Styles */
+.payment-radio-item {
+    display: flex;
+    align-items: center;
+    padding: 20px; /* 여백 확대 */
+    border-bottom: 1px solid #eee;
+    cursor: pointer;
+    font-size: 11px; /* 폰트 사이즈 조정 */
+    color: #888; /* 기본 컬러 연하게 */
+}
+
+/* Hide default radio input */
+.payment-radio-item input {
+    display: none;
+}
+
+.payment-radio-item.selected {
+    border: 1px solid #000; /* Selected Box Border */
+    margin-top: -1px; 
+    margin-bottom: -1px;
+    position: relative;
+    z-index: 10; /* 위로 올라오게 */
+    font-weight: bold;
+    color: #000; /* 선택된 텍스트 진하게 */
+    background: #fff;
 }
 
 .mt-2 {

--- a/frontend/src/components/order/ShippingForm.vue
+++ b/frontend/src/components/order/ShippingForm.vue
@@ -557,7 +557,7 @@ const couponCount = ref(0); // 기본값 0
 const mileageBalance = ref(0); // 기본값 0
 const depositBalance = ref(0); // 기본값 0
 const usedMileage = ref(''); // [수정] 기본값 0 -> 공란
-const usedDeposit = ref(0); // Changed from '' to 0 to avoid redeclaration and ensure syntactic correctness
+const usedDeposit = ref(''); // 기본값 빈 문자열
 const paymentMethod = ref('card'); // 기본값 카드
 const savePaymentInfo = ref(true); // Save Payment Info Checkbox (Default: true)
 


### PR DESCRIPTION
## 💡 개요
> 결제 정보 입력 및 결제 완료 시 API 연동되어 orders 테이블에 데이터 추가 완료

## 🔗 관련 이슈
Closes #115 

## 📝 작업 상세 내용
- [ ] 결제하기 버튼 클릭시 확인 창이 뜬 뒤 확인을 누르면 orders 테이블에 데이터 저장
- [ ] 결제별 도움 메시지 나오도록 작성
- [ ] 기타 디자인 인사일런스 화면과 최대한 동일하게 구현

## 📸 스크린샷 (Optional)
<img width="917" height="806" alt="image" src="https://github.com/user-attachments/assets/6058c7be-b0a9-4618-9b19-6020a6e2c7cd" />

<img width="561" height="224" alt="image" src="https://github.com/user-attachments/assets/097702c5-6442-4ba9-8337-38e0f39eb6ff" />

<img width="560" height="174" alt="image" src="https://github.com/user-attachments/assets/7fe1dac1-7b7c-4e5b-bffc-6007d56e73ad" />

<img width="1608" height="36" alt="image" src="https://github.com/user-attachments/assets/e394bd5c-a0ed-49a5-bd97-6588d4c84c43" />

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.