### PR TITLE
feat(FE): Header.vue 수정 (#132)

### DIFF
--- a/frontend/src/components/layout/Header.vue
+++ b/frontend/src/components/layout/Header.vue
@@ -310,6 +310,7 @@ a {
 
 /* [드롭다운] */
 /* [미니 드롭다운] - 고객센터, 계정 등 */
+/* [미니 드롭다운] - 고객센터, 계정 등 */
 .relative_item {
   position: relative;
   height: 100%;
@@ -319,31 +320,48 @@ a {
 
 .mini_dropdown {
   position: absolute;
-  top: 30px; /* 텍스트 바로 아래 */
+  top: 30px;
   left: 50%;
   transform: translateX(-50%);
   background: #fff;
   border: 1px solid #000;
-  min-width: 100px;
+  min-width: 110px; /* 너비 축소 */
   display: flex;
   flex-direction: column;
   gap: 0;
   z-index: 100;
+  padding: 10px 0 !important; /* 상하 패딩 축소 */
+  margin: 0 !important;
+  list-style: none !important;
 }
 
 .mini_dropdown li {
-  width: 100%;
-  text-align: left; /* 왼쪽 정렬 */
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 0 !important;
+  width: 100% !important;
+  text-align: center !important; /* 중앙 정렬 */
+  display: block !important;
+  min-height: auto !important;
+  height: auto !important;
+  line-height: normal !important;
 }
 
 .mini_dropdown a {
-  display: block;
-  padding: 3px 15px; /* 상하 간격 매우 좁게 */
-  font-size: 11px; /* 기존폰트 유지 */
-  color: #000;
-  font-weight: 400;
-  text-decoration: none;
-  white-space: nowrap;
+  display: block !important;
+  padding: 3px 0 !important; /* 항목 간격 더 배짝 붙임 */
+  font-size: 11px !important;
+  color: #000 !important;
+  font-weight: 400 !important;
+  text-decoration: none !important;
+  white-space: nowrap !important;
+  background-color: transparent !important;
+  line-height: 1.2 !important; /* 줄 간격도 줄임 */
+}
+
+.mini_dropdown a:hover {
+  text-decoration: underline !important;
+  background-color: transparent !important;
 }
 
 .mini_dropdown a:hover {

--- a/frontend/src/components/layout/Header.vue
+++ b/frontend/src/components/layout/Header.vue
@@ -310,12 +310,17 @@ a {
 
 /* [드롭다운] */
 /* [미니 드롭다운] - 고객센터, 계정 등 */
-/* [미니 드롭다운] - 고객센터, 계정 등 */
 .relative_item {
   position: relative;
   height: 100%;
   display: flex;
   align-items: center;
+}
+
+/* 텍스트 수직 보정 (지구본 등 다른 아이콘과 높이 맞춤) */
+.relative_item > a {
+  padding-top: 3px;
+  display: inline-block;
 }
 
 .mini_dropdown {


### PR DESCRIPTION
## 💡 개요
> 로그인 시 계정 서브메뉴 변경 및 기타 스타일 수정

## 🔗 관련 이슈
Closes #132

## 📝 작업 상세 내용
- [x] 로그인 시 로그아웃, 정보수정 서브메뉴 추가
- [x] 서브메뉴 여백 제거
- [x] 우측 메뉴 수직 보정

## 📸 스크린샷 (Optional)
<img width="345" height="55" alt="image" src="https://github.com/user-attachments/assets/0e3d51ad-5e45-437e-8966-25660f7fb5f0" />

<img width="129" height="248" alt="image" src="https://github.com/user-attachments/assets/c5295bf0-d20b-437e-bf80-bd4deaed50d4" />


## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.