### PR TITLE
fix, feat(FE): 즉시구매 에러 로직 수정 및 마이페이지 주문 상세 조회 기능 추가 (#139, #140)

### DIFF
--- a/frontend/src/views/member/mypage/OrderListPage.vue
+++ b/frontend/src/views/member/mypage/OrderListPage.vue
@@ -112,12 +112,14 @@
       </button>
     </div>
 
-    <!-- Order Detail Modal -->
+    <!-- Order Detail Modal (페이지 이동으로 변경되어 미사용) -->
+    <!--
     <OrderDetailModal
       v-if="showDetailModal"
       :orderId="selectedOrderId"
       @close="closeDetailModal"
     />
+    -->
   </div>
 </template>
 
@@ -338,14 +340,20 @@ async function fetchOrders() {
 }
 
 function viewOrderDetail(orderId) {
-  selectedOrderId.value = orderId
-  showDetailModal.value = true
+  // 모달 대신 페이지 이동으로 변경
+  router.push({
+    path: '/order/complete',
+    query: {
+      orderId: orderId,
+      mode: 'detail' // 상세 조회 모드
+    }
+  });
 }
-
-function closeDetailModal() {
-  showDetailModal.value = false
-  selectedOrderId.value = null
-}
+/* 모달 관련 코드 주석 처리 또는 제거 */
+// function closeDetailModal() {
+//   showDetailModal.value = false
+//   selectedOrderId.value = null
+// }
 
 async function handleCancelOrder(orderId) {
   if (!confirm('정말 주문을 취소하시겠습니까?')) {


### PR DESCRIPTION
## 💡 개요
> 즉시구매 에러 로직 수정 및 마이페이지 주문 상세 조회 기능 추가

## 🔗 관련 이슈
Closes #139 
Closes #140 

## 📝 작업 상세 내용
- [x] `ProductDetail.vue` 쿼리 파라미터 수정
- [x] `mypage/orders` API를 가져온 뒤 상품 정보를 채워놓도록 로직 수정

## 📸 스크린샷 (Optional)
<img width="182" height="46" alt="image" src="https://github.com/user-attachments/assets/89e63233-8d7d-4bca-9290-381287e39d09" />

<img width="1028" height="793" alt="image" src="https://github.com/user-attachments/assets/4a2d6e41-48b1-4a3e-a1c0-e514ca92a307" />

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.