### PR TITLE
fix(common): 프론트엔드 공통 파일 오류 수정 (#151) 

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8080

--- a/frontend/src/api/http.js
+++ b/frontend/src/api/http.js
@@ -9,6 +9,7 @@ const http = axios.create({
     headers: { 'Content-Type' : 'application/json'},
     timeout: 10000,
 })
+console.log('BASE_URL:', import.meta.env.VITE_API_BASE_URL)
 
 http.interceptors.request.use((config) => {
     const url = config.url || ''

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,11 +2,6 @@ import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'
 import router from './router'
-import axios from 'axios'
-
-// 모든 axios 요청에 쿠키(세션)를 포함시킴
-axios.defaults.baseURL = 'http://localhost:8080';
-axios.defaults.withCredentials = true; // 백엔드 로그인 정보 전달
 
 const app = createApp(App)
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
         proxy: {
             // 프론트에서 /api로 시작하는 요청을 보내면 백엔드로 배달해줌
             '/api': {
-                target: 'http://localhost:5050', // 👈 여기에 백엔드 주소/포트 입력
+                target: 'http://localhost:8080', // 👈 여기에 백엔드 주소/포트 입력
                 changeOrigin: true,
                 secure: false,
                 // 필요에 따라 rewrite 설정 (현재 백엔드 주소에 /api가 포함되어 있으므로 그대로 둠)


### PR DESCRIPTION
## 💡 개요
> vite.config.js target 오류 및 axios 이중 사용 수정, base url 복구

## 🔗 관련 이슈
Closes #151 

## 📝 작업 상세 내용
- [ ] vite.config.js target 5050 -> 8080 수정
- [ ] .env.development에 있던 base url이 삭제되어 복구함
- [ ] index.js에 axios 설정을 해두었으나 main.js에 설정을 추가해 이중 사용되어 삭제함

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [ ] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?
- [ ] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.